### PR TITLE
Small PR - updating local links

### DIFF
--- a/docs/source/overview/scope.md
+++ b/docs/source/overview/scope.md
@@ -2,7 +2,7 @@
 
 Several of the groups that have worked on supporting and developing the modeling hubs came together in 2022 to initiate a community-driven effort to generalize hub-related tools that were developed “on the go” during the first two years of the COVID-19 pandemic.
 
-The goal of the Consortium of Infectious Disease Modeling Hubs is to develop a central open-source suite of tools for creating, hosting, maintaining, and running a modeling hub. As mentioned [previously](https://hubdocs.readthedocs.io/en/latest/overview/who-we-are.html), while the focus of the motivating applications were related to predictive time-series-style modeling of outbreaks, the tools developed as part of this effort are designed to be more general and could be used for other purposes, e.g., for aggregating estimates of parameters of interest.
+The goal of the Consortium of Infectious Disease Modeling Hubs is to develop a central open-source suite of tools for creating, hosting, maintaining, and running a modeling hub. As mentioned [previously](who-we-are.md), while the focus of the motivating applications were related to predictive time-series-style modeling of outbreaks, the tools developed as part of this effort are designed to be more general and could be used for other purposes, e.g., for aggregating estimates of parameters of interest.
 
 The ultimate goal of this project is to provide a suite of portable and open-source resources that could be relatively easily adapted by new modeling hubs without the need to duplicate efforts.
 

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -56,7 +56,7 @@ The [output_type](#output-types) object defines accepted representations for eac
 (target-metadata)=
 ## Target metadata
 
-Target metadata is an array in the [tasks.json](https://hubdocs.readthedocs.io/en/latest/user-guide/hub-config.html#hub-model-task-configuration-tasks-json-file) schema file that defines the characteristics of each target.
+Target metadata is an array in the [tasks.json](#tasks-metadata) schema file that defines the characteristics of each target.
 
 It is composed of the following fields:
 * `target_id`: a short description that uniquely identifies the target.


### PR DESCRIPTION
Spurred by [Lucie's discussion](https://github.com/orgs/hubverse-org/discussions/22) about changing links to hubverse.io from hubdocs.readthedocs.io I decided to check if there were outdated links, and only found two. I removed them and changed them to local links (which should continue working even if the website changes name again).