### PR TITLE
enable tasklists

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,8 @@ myst_enable_extensions = [
     "deflist",
     "dollarmath",
     "fieldlist",
-    "substitution"
+    "substitution",
+    "tasklist"
 ]
 
 # -- Options for HTML output


### PR DESCRIPTION
The MyST parser does not include task lists by default, so the extension has to be enabled.