### PR TITLE
Adding packages, changing order, others

### DIFF
--- a/docs/source/user-guide/software.md
+++ b/docs/source/user-guide/software.md
@@ -12,7 +12,7 @@ To assist users in building a hub, we have developed a software suite with speci
 
 ## [`hubCI`](https://github.com/hubverse-org/hubCI)  
 
-`hubCI` is an R package that provides functionality for setting up hubverse Continuous Integration workflows. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubCI).  
+`hubCI` is an R package that provides functionality for setting up hubverse continuous integration workflows. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubCI).  
 
 ## [`hubData`](https://github.com/hubverse-org/hubData)  
 

--- a/docs/source/user-guide/software.md
+++ b/docs/source/user-guide/software.md
@@ -2,35 +2,41 @@
 
 To assist users in building a hub, we have developed a software suite with specific functions and uses outlined below. These tools are designed to support common modeling hub tasks, like loading model output data, plotting the model output data, building ensembles using the data, and in some cases evaluating the predictions made by different models.  
 
+## [`hubverse`](https://github.com/hubverse-org/hubverse)  
+
+`hubverse` is a collection of packages that enables collaborative modeling exercises through a unified framework for aggregating, visualizing, and evaluating forecasts. Notably, **installing `hubverse` also installs all of the other packages listed below**. It is designed to make it easy to install and load multiple `hubverse` packages in a single step. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubverse).  
+
 ## [`hubAdmin`](https://github.com/hubverse-org/hubAdmin)  
 
-`hubAdmin` is an R package that contains utility functions for administering hubs, in particular creating and validating hub configuration files. You can find the complete package and instructions for use [here](https://github.com/hubverse-org/hubAdmin).    
+`hubAdmin` is an R package that provides a set of utility functions for administering hubs, in particular creating and validating hub configuration files. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubAdmin).  
+
+## [`hubCI`](https://github.com/hubverse-org/hubCI)  
+
+`hubCI` is an R package that provides functionality for setting up hubverse Continuous Integration workflows. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubCI).  
 
 ## [`hubData`](https://github.com/hubverse-org/hubData)  
 
-`hubData` is an R package that provides tools for connecting to, interacting with, and manipulating hub data. You can find the complete package and instructions for use [here](https://github.com/hubverse-org/hubData).   
+`hubData` is an R package that provides tools for connecting to, interacting with, and manipulating hub data. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubData).  
 
 ## [`hubEnsembles`](https://github.com/hubverse-org/hubEnsembles)  
 
-`hubEnsembles` is an R package with functionality to build simple ensembles of data from modeling hubs. Different ensembles can be built using for instance the mean, median, and mode. You can find the complete package and instructions for use [here](https://github.com/hubverse-org/hubEnsembles).  
+`hubEnsembles` is an R package with functionality to build simple ensembles of data from modeling hubs. Different ensembles can be built using for instance the mean, median, and mode. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubEnsembles).  
+
+## [`hubEvals`](https://github.com/hubverse-org/hubEvals)  
+
+`hubEvals` is an R package that provides tools for evaluating infectious disease model outputs. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubEvals).  
 
 ## [`hubExamples`](https://github.com/hubverse-org/hubExamples)  
 
-`hubExamples` is an R package that provides example data for forecasting and scenario modeling hubs in the hubverse format. You can find the complete package and instructions for use [here](https://github.com/hubverse-org/hubExamples). 
+`hubExamples` is an R package that provides example data for forecasting and scenario modeling hubs in the hubverse format. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubExamples).  
 
 ## [`hubUtils`](https://hubverse-org.github.io/hubUtils/)  
 
-`hubUtils` is a lightweight R package that primarily contains general utilities imported by other hubverse packages. Previously, `hubUtils` was a larger package with more functions, but most of these were moved and split across `hubData` and `hubAdmin`.   
+`hubUtils` is a lightweight R package that primarily contains general utilities imported by other hubverse packages. Previously, `hubUtils` was a larger package with more functions, but most of these were moved and split across `hubData` and `hubAdmin`. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubUtils).  
 
 ## [`hubValidations`](https://github.com/hubverse-org/hubValidations)  
 
-`hubValidations` is an R package that facilitates the implementation of general validation rules that are enforced on submissions in the form of pull requests to hub repositories. You can find the complete package and instructions for use [here](https://github.com/hubverse-org/hubValidations).  
-
-## [`hubverse`](https://github.com/hubverse-org/hubverse) 
-
-`hubverse` is a collection of packages that enables collaborative modeling exercises through a unified framework for aggregating, visualizing,
-and evaluating forecasts. This package is designed to make it easy to install and load multiple `hubverse` packages in a single step. You can
-find the complete package and instructions for use [here](https://github.com/hubverse-org/hubverse).  
+`hubValidations` is an R package that facilitates the implementation of general validation rules that are enforced on submissions in the form of pull requests to hub repositories. You can find [the complete package and instructions here](https://github.com/hubverse-org/hubValidations).  
 
 ## [`hubVis`](https://github.com/hubverse-org/hubVis)  
 


### PR DESCRIPTION
These are the main changes made to the software section with explanations:

1. `hubverse` is listed as the first package, since it includes all the other packages, and may be the only one needed to download. I also bolded that it includes the rest of the packages.
2. I added descriptions for packages that were not listed in this section (and are part of `hubverse` - namely `hubCI` and `hubEvals`.
3. After playing with the order of packages, and going through their descriptions and functions, there was no obvious hierarchy I could see in which to list them, and opted to list them in alphabetical order. Given there are many packages now, this provides two main benefits: (i) it is easier to find a specific package if they are in order; and (ii) it aligns more closely with how they would display if you only download `hubverse`.
4. I changed the hyperlinked text from "here" to "the complete package and instructions here". This is for accessibility issues for people who use screen readers. Here is [one source on accessible hyperlinks](https://www.nysed.gov/webaccess/create-accessible-hypertext-links).