### PR TITLE
Clarify model-outputs section

### DIFF
--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -83,7 +83,7 @@ As shown in [the model output submission table](#model-output-example-table) abo
       ID" columns as described [in this section on task ID
       variables](#task-id-vars). These "task ID" columns may also include
       additional information, such as any conditions or assumptions that were
-      used to generate the predictions. Some example variables include
+      used to generate the predictions. Some example task ID variables include
       `target`, `location`, `reference_date`, and `horizon`.    Although there
       are no restrictions on naming task ID variables, when appropriate, we
       suggest that Hubs adopt the standard task ID or column names and
@@ -91,7 +91,7 @@ As shown in [the model output submission table](#model-output-example-table) abo
       variables](#task-id-use).  
    3. **"Model output representation" (3 columns)**: consists of a set of three
       columns specifying how the model outputs are represented. All three of
-      these columns will be used by all Hubs:  
+      these columns will be present in all model output data:  
       1. `output_type` specifies the type of representation of the predictive
          distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`,
          `"cmf"`, `"pmf"`, or `"sample"`.  
@@ -183,8 +183,8 @@ from the `hubValidations` R package, which performs two validation tasks:
 
 ```{admonition} NOTE
 The following discussion addresses two different types of schemas:
- - [hubverse schema](https://github.com/hubverse-org/schemas)---the schema for **validating hub configuration files**
- - [arrow schema](https://arrow.apache.org/docs/11.0/r/reference/Schema.html)---the schema for **model output columns in parquet files**.
+ - [hubverse schema](https://github.com/hubverse-org/schemas)---the schema used for **validating hub configuration files**
+ - [arrow schema](https://arrow.apache.org/docs/11.0/r/reference/Schema.html)---the mapping of model output columns to arrow data types.
 
 This section is primarily a concern for parquet files, which encapsulate a schema within the file, but the broader issues have consequences for all output filetypes.
 ```
@@ -192,7 +192,7 @@ This section is primarily a concern for parquet files, which encapsulate a schem
 
 Model output data are stored as separate files, but we use the `hubData` package to open them as a single [arrow dataset](https://arrow.apache.org/docs/r/reference/Dataset.html).[^trouble]
 **It is necesssary to ensure that all files conform to the same arrow schema** (i.e. share the same column data types) across the lifetime of the hub.
-When we know that all data types conform to the arrow schema, we can be sure that a hub can be [successfully accessed and fully queryable across all columns as an arrow dataset](https://arrow.apache.org/docs/r/articles/dataset.html)
+When we know that all data types conform to the arrow schema, we can be sure that a hub can be [successfully accessed and is fully queryable across all columns as an arrow dataset](https://arrow.apache.org/docs/r/articles/dataset.html)
 This means that **additions of new rounds _should not_ change the overall hub schema at a later date** (i.e. after submissions have already started being collected). 
 
 [^trouble]: Even if you do not use `hubData` to read model outputs, uniform schemas are still important if you want to join model output files and do analyses across submissions.

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -148,7 +148,7 @@ More details about sample-output-type can be found in [the page describing sampl
 
 Some other possible model output representations have been proposed, but are not included on the list above. We document these other proposals and the reasons for their omissions here:
 
-#### Point forecasts
+#### Point estimates
 
 * Bin probability. Two notes:
    * If the bins have open left endpoints and closed right endpoints, bin probabilities can be calculated directly from CDF values.
@@ -157,10 +157,10 @@ Some other possible model output representations have been proposed, but are not
       * It might be beneficial to adopt limited standards that encourage Hubs to adopt settings that are consistent with the common definitions. For example, if a Hub were to adopt bins with open right endpoints, the resulting probabilities would be incompatible with the conventions around cumulative distribution functions.
 * Probability of “success” in a setting with a binary outcome
    * This can be captured with a CDF representation if the outcome variable is ordered, or a categorical representation if the outcome variable is not ordered.
-* Compositional. For example, we might request a probabilistic forecast of the proportion of hospitalizations next week that are due to influenza A/H1, A/H3, and B.
-   * Note that if only point forecasts for the composition were required, a categorical output representation could be used.
+* Compositional. For example, we might request a probabilistic estimate of the proportion of hospitalizations next week that are due to influenza A/H1, A/H3, and B.
+   * Note that if only point estimates for the composition were required, a categorical output representation could be used.
 
-## Validating forecast values
+## Validating prediction values
 
 Before model outputs can be incorporated into a hub, they must be validated. If a hub is centrally stored on GitHub, validations checks will be automatically performed for each submission (via the [`validate_pr()` function](https://hubverse-org.github.io/hubValidations/reference/validate_submission.html) from the `hubValidations` R package).  
 

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -181,10 +181,11 @@ from the `hubValidations` R package, which performs two validation tasks:
 ```{admonition} NOTE
 The following discussion addresses two different types of schemas:
  - [hubverse schema](https://github.com/hubverse-org/schemas)---the schema for **validating hub configuration files**
- - [arrow schema](https://arrow.apache.org/docs/11.0/r/reference/Schema.html)---the schema for **model output columns in parquet files**[^csv]
+ - [arrow schema](https://arrow.apache.org/docs/11.0/r/reference/Schema.html)---the schema for **model output columns in parquet files**.
+
+This section is primarily a concern for parquet files, which encapsulate a schema within the file, but the broader issues have consequences for all output filetypes.
 ```
 
-[^csv]: This section is primarily a concern for parquet files, which encapsulate a schema within the file, but the broader issues have consequences for all output filetypes.
 
 Model output data are stored as separate files, but we use the `hubData` package to open them as a single [arrow dataset](https://arrow.apache.org/docs/r/reference/Dataset.html).
 **It is necesssary to ensure that all files conform to the same arrow schema** (i.e. share the same column data types) across the lifetime of the hub.

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -162,7 +162,9 @@ Some other possible model output representations have been proposed, but are not
 
 ## Validating forecast values
 
-Validation of forecast submissions is done with the function 
+Before model outputs can be incorporated into a hub, they must be validated. If a hub is centrally stored on GitHub, validations checks will be automatically performed for each submission (via the [`validate_pr()` function](https://hubverse-org.github.io/hubValidations/reference/validate_submission.html) from the `hubValidations` R package).  
+
+Teams can also validate their submissions locally via the function 
 [`validate_submissions()`](https://hubverse-org.github.io/hubValidations/reference/validate_submission.html)
 from the `hubValidations` R package, which performs two validation tasks:
 

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -99,7 +99,7 @@ More detail about each of these column groups is given in the following points:
   3. `value` contains the model’s prediction.
 
 
-The following table provides examples that better explain how the "model output representation" columns are used:
+The following table provides more detail on how to configure the three "model output representation" columns based on each model output type:
 
 (output-type-table)=
 :::{table} Relationship between the three model output representation columns with respect to the type of prediction (`output_type`)

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -201,7 +201,7 @@ However, there are a number of situations where a single consistent data type ca
 - Adding new output types, which might introduce `output_type_id` values of a new data type.
 
 While validation of config files will alert hub administrations to discrepancies in task ID value data types across modeling tasks and rounds, modifications that will change the overall data type of model output columns _after submissions have been collected_ could cause downstream issues and _should be avoided_.
-Some examples of issues caused by a change in the overal data type of model output columns:
+Changing the overall data type of model output columns can cause a range of issues (in order of _increasing severity_):
  - data type casting being required in downstream analysis code that used to work, 
  - not being able to filter on columns with data type discrepancies between files before collecting
  - errors when opening hub model output data with popular analytics tools like arrow, pandas, and polars

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -194,7 +194,7 @@ This means that **additions of new rounds _should not_ change the overall hub sc
 
 [^trouble]: Even if you do not use `hubData` to read model outputs, uniform schemas are still important if you want to join model output files and do analyses across submissions.
 
-Many common task IDs should have consistent and stable data types because they are validated during hub configuration.
+Many common task IDs should have consistent and stable data types because they are validated against [the task IDs in the hubverse schema](#model-tasks-tasks-json-interactive-schema) during model submission.
 However, there are a number of situations where a single consistent data type cannot be guaranteed, e.g.:
 - New rounds introducing changes in custom task ID value data types, which are not covered by the hubverse schema. 
 - New rounds introducing changes in task IDs covered by the schema but which accept multiple data types (e.g. `scenario_id` where both `integer` and `character` are accepted or `age_group` where no data type is specified in the hubverse schema).

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -42,19 +42,22 @@ one-week-ahead incidence, but probabilities for the timing of a season peak:
 
 ### File formats
 
-Hubs can take submissions in tabular data formats, namely CSV and parquet. Hubs
-can be set up to take either or both if necessary. Both have advantages and
-tradeoffs:
+Hubs can take submissions in tabular data formats, namely `csv` and `parquet`. These
+submission formats are _not mutuatlly exclusive_; **Hubs may choose between
+ `parquet` (arrow) `csv`, or both**. Both formats have advantages and tradeoffs:
 
 * Considerations about `csv`:
-   1. Some projects have run into 100 MB file size limits when using csv formatted files.
+   * Advantages
+     * Compatibility: Files are human-readable and are widely supported by many tools
+   * Disadvantages:
+     * Size: Some projects have run into 100 MB file size limits when using `csv` formatted files.
 * Considerations about `parquet`:
    * Advantages:
       * Speed
-      * Size: In combination, splitting files up and using parquet would get around GitHub limits on file sizes
+      * Size: In combination, splitting files up and using `parquet` would get around GitHub limits on file sizes
       * Loads only data that are needed
    * Disadvantages:
-      * Harder to work with; teams and people who want to work with files need to install additional libraries
+      * Compatibility: Harder to work with; teams and people who want to work with files need to install additional libraries
 
 
 (model-output-format)=

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -23,21 +23,21 @@ is an example for a Hub that collects mean and quantile forecasts for
 one-week-ahead incidence, but probabilities for the timing of a season peak:  
 
 :::{table} An example of a model output submission for modelA
-| `model_id` | `origin_epiweek` | `target` | `horizon` | `output_type` | `output_type_id` | `value` |
-| ---------- | ------ | ------ | ------ | ------ | ------ | ------ | 
-| modelA | EW202242 | weekly rate | 1 | mean     | NA | 5 |
-| modelA | EW202242 | weekly rate | 1 | quantile | 0.25 | 2 |
-| modelA | EW202242 | weekly rate | 1 | quantile | 0.5 | 3 |
-| modelA | EW202242 | weekly rate | 1 | quantile | 0.75 | 10 |
-| modelA | EW202242 | weekly rate | 1 | pmf | 0 | 0.1 |
-| modelA | EW202242 | weekly rate | 1 | pmf | 0.1 | 0.2 |
-| modelA | EW202242 | weekly rate | 1 | pmf | 0.2 | 0.7 |
-| modelA | EW202242 | peak week | NA | pmf | EW202240 | 0.001 |
-| modelA | EW202242 | peak week | NA | pmf | EW202241 | 0.002 |
-| modelA | EW202242 | ... | ... | ... | ... | ... |
-| modelA | EW202242 | peak week | NA | pmf | EW202320 | 0.013 |
-| modelA | EW202242 | weekly rate | 1 | sample | 1 | 3 |
-| modelA | EW202242 | weekly rate | 1 | sample | 2 | 3 |
+| `origin_epiweek` | `target` | `horizon` | `output_type` | `output_type_id` | `value` |
+| ------ | ------ | ------ | ------ | ------ | ------ | 
+| EW202242 | weekly rate | 1 | mean     | NA | 5 |
+| EW202242 | weekly rate | 1 | quantile | 0.25 | 2 |
+| EW202242 | weekly rate | 1 | quantile | 0.5 | 3 |
+| EW202242 | weekly rate | 1 | quantile | 0.75 | 10 |
+| EW202242 | weekly rate | 1 | pmf | 0 | 0.1 |
+| EW202242 | weekly rate | 1 | pmf | 0.1 | 0.2 |
+| EW202242 | weekly rate | 1 | pmf | 0.2 | 0.7 |
+| EW202242 | peak week | NA | pmf | EW202240 | 0.001 |
+| EW202242 | peak week | NA | pmf | EW202241 | 0.002 |
+| EW202242 | ... | ... | ... | ... | ... |
+| EW202242 | peak week | NA | pmf | EW202320 | 0.013 |
+| EW202242 | weekly rate | 1 | sample | 1 | 3 |
+| EW202242 | weekly rate | 1 | sample | 2 | 3 |
 :::
 
 ### File formats
@@ -71,36 +71,35 @@ Much of the material in this section has been excerpted and/or adapted from the 
 
 _Model outputs are a specially formatted tabular representation of predictions._
 Each row corresponds to a single, unique prediction and each column provides information about what is being predicted, its scope, and its value. 
-Per hubverse convention, **there are three groups of columns**, each group serving a specific purpose: (1) the **"model ID"** is a single column that denotes which model has produced the prediction, (2) the **"task ID"** columns provide details about what is being predicted, and (3) the three **"model output representation"** columns specifies the type of prediction, identifying information about that prediction, and the value of the prediction. 
+Per hubverse convention, **there are two groups of columns**[^model-id], each group serving a specific purpose: (1) the **"task ID"** columns provide details about what is being predicted, and (2) the three **"model output representation"** columns specifies the type of prediction, identifying information about that prediction, and the value of the prediction. 
 
-As shown in [the model output submission table](#model-output-example-table) above, the
-**"model ID"** is in the `model_id` column; there are 3 **"task ID"** columns: `origin_epiweek`, `target`, and `horizon`; and finally there are three **"model output representation"** columns: `output_type`, `output_type_id`, and `value`. More detail about each of these column groups is given in the following points:  
+[^model-id]: When using models for downstream analysis with [the `collect_hub()` function](https://hubverse-org.github.io/hubData/reference/collect_hub.html) in the `hubData` package, one more column called `model_id` is prepended added that identifies the model from its filename. 
 
-   1. **"Model ID" (1 column)**: Each model should have a unique identifier
-      that is stored in the `model-id` column.
-   2. **"Task IDs" (multiple columns)**:  The details of the outcome (the model
-      task) are provided by the modeler, and can be stored in a series of "task
-      ID" columns as described [in this section on task ID
-      variables](#task-id-vars). These "task ID" columns may also include
-      additional information, such as any conditions or assumptions that were
-      used to generate the predictions. Some example task ID variables include
-      `target`, `location`, `reference_date`, and `horizon`.    Although there
-      are no restrictions on naming task ID variables, when appropriate, we
-      suggest that Hubs adopt the standard task ID or column names and
-      definitions specified [in the section on usage of task ID
-      variables](#task-id-use).  
-   3. **"Model output representation" (3 columns)**: consists of a set of three
-      columns specifying how the model outputs are represented. All three of
-      these columns will be present in all model output data:  
-      1. `output_type` specifies the type of representation of the predictive
-         distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`,
-         `"cmf"`, `"pmf"`, or `"sample"`.  
-      2. `output_type_id` specifies more identifying information specific to
-         the output type, which varies depending on the `output_type`
-      3. `value` contains the model’s prediction.  
+As shown in [the model output submission table](#model-output-example-table) above, there are 3 **"task ID"** columns: `origin_epiweek`, `target`, and `horizon`; and fithere are three **"model output representation"** columns: `output_type`, `output_type_id`, and `value`.
+More detail about each of these column groups is given in the following points:  
+
+1. **"Task IDs" (multiple columns)**:  The details of the outcome (the model
+   task) are provided by the modeler, and can be stored in a series of "task
+   ID" columns as described [in this section on task ID
+   variables](#task-id-vars). These "task ID" columns may also include
+   additional information, such as any conditions or assumptions that were used
+   to generate the predictions. Some example task ID variables include
+   `target`, `location`, `reference_date`, and `horizon`.    Although there are
+   no restrictions on naming task ID variables, when appropriate, we suggest
+   that Hubs adopt the standard task ID or column names and definitions
+   specified [in the section on usage of task ID variables](#task-id-use).
+2. **"Model output representation" (3 columns)**: consists of a set of three
+   columns specifying how the model outputs are represented. All three of these
+   columns will be present in all model output data:
+  1. `output_type` specifies the type of representation of the predictive
+     distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`,
+     `"pmf"`, or `"sample"`.
+  2. `output_type_id` specifies more identifying information specific to the
+     output type, which varies depending on the `output_type`
+  3. `value` contains the model’s prediction.
 
 
-The following table provides examples that better explain how the "model output representation" columns are used:  
+The following table provides examples that better explain how the "model output representation" columns are used:
 
 (output-type-table)=
 :::{table} Relationship between the three model output representation columns with respect to the type of prediction (`output_type`)

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -3,12 +3,12 @@
 ## Directory structure
 The `model-output` directory in a modeling hub is required to have the following subdirectory and file structure:
 
-* `team1-modela`
+* `team1-modelA`
    * `<round-id1>-<model_id>.csv` (or parquet, etc)
    * `<round-id2>-<model_id>.csv` (or parquet, etc)
-* `team1-modelb`
+* `team1-modelB`
    * `<round-id1>-<model_id>.csv` (or parquet, etc)
-* `team2-modela`
+* `team2-modelA`
    * `<round-id1>-<model_id>.csv` (or parquet, etc)
 
 where `model_id` = `team_abbr-model_abbr`
@@ -17,13 +17,12 @@ Note that file names are also allowed to contain the following compression exten
 
 (model-output-format)=
 ## Formats of model output
-```{margin}
-Shandross, L., Howerton, E., Contamin, L., Hochheiser, H., Krystalli, A., Consortium of Infectious Disease Modeling Hubs, Reich, N. G., Ray, E.L. (2024). [hubEnsembles: Ensembling Methods in R](https://github.com/hubverse-org/hubEnsemblesManuscript). *(under review for publication)*.
-```
 
 ```{admonition} Reference
-Much of the material in this section has been excerpted and/or adapted from the [hubEnsembles manuscript](https://github.com/hubverse-org/hubEnsemblesManuscript).  
+Much of the material in this section has been excerpted and/or adapted from the [hubEnsembles manuscript](https://github.com/hubverse-org/hubEnsemblesManuscript).[^Shandross-etal]
 ```
+
+[^Shandross-etal]: Shandross, L., Howerton, E., Contamin, L., Hochheiser, H., Krystalli, A., Consortium of Infectious Disease Modeling Hubs, Reich, N. G., Ray, E.L. (2024). [hubEnsembles: Ensembling Methods in R](https://github.com/hubverse-org/hubEnsemblesManuscript). *(under review for publication)*.
 
 Model outputs are a specially formatted tabular representation of predictions. Each row corresponds to a single, unique prediction and each column provides information about what is being predicted, its scope, and its value. Per hubverse convention, there are three groups of columns, each group serving a specific purpose: (1) the "model ID" denotes which model has produced the prediction, (2) the "task IDs" provide details about what is being predicted, and (3) the "model output representation" specifies how the prediction is represented. More detail about each of these is given in the following points:  
 
@@ -36,27 +35,22 @@ Model outputs are a specially formatted tabular representation of predictions. E
      
 The following table provides examples that better explain how the "model output representation" columns are used:  
 
-```{margin}
-Note on `pmf` model output type: Values are required to sum to 1 across all `output_type_id` values within each combination of values of task id variables. This representation should only be used if the outcome variable is truly discrete; if the categories would represent a binned discretization of an underlying continuous variable  a CDF representation is preferred.
-```
-
-```{margin}
-Note on `sample` model output type: Depending on the Hub specification, samples with the same sample index (specified by the `output_type_id`) may be assumed to correspond to a single sample from a joint distribution across multiple levels of the task id variables. This is discussed more below.
-```
-
-```{margin}
-Note on `cdf` model output type and `pmf` output type for ordinal variables: In the hub's `tasks.json` configuration file, the values of the `output_type_id` should be listed in order from low to high.
-```
 (output-type-table)=
 | `output_type` | `output_type_id` | `value` |
 | ------ | ------ | ------ | 
 | `mean` | NA (not used for mean predictions) | Numeric: the mean of the predictive distribution |
 | `median` | NA (not used for median predictions) | Numeric: the median of the predictive distribution |
 | `quantile` | Numeric between 0.0 and 1.0: a probability level | Numeric: the quantile of the predictive distribution at the probability level specified by the output_type_id |
-| `cdf` | String or numeric: a possible value of the target variable | Numeric between 0.0 and 1.0: the value of the cumulative distribution function of the predictive distribution at the value of the outcome variable specified by the output_type_id |
-| `pmf` | String naming a possible category of a discrete outcome variable | Numeric between 0.0 and 1.0: the value of the probability mass function of the predictive distribution when evaluated at a specified level of a categorical outcome variable. |
-| `sample` | Positive integer sample index | Numeric: a sample from the predictive distribution.
+| `cdf`[^cdf] | String or numeric: a possible value of the target variable | Numeric between 0.0 and 1.0: the value of the cumulative distribution function of the predictive distribution at the value of the outcome variable specified by the output_type_id |
+| `pmf`[^pmf] | String naming a possible category of a discrete outcome variable | Numeric between 0.0 and 1.0: the value of the probability mass function of the predictive distribution when evaluated at a specified level of a categorical outcome variable.[^cdf] |
+| `sample`[^sample] | Positive integer sample index | Numeric: a sample from the predictive distribution.
 
+
+[^pmf]: **Note on `pmf` model output type**: Values are required to sum to 1 across all `output_type_id` values within each combination of values of task id variables. This representation should only be used if the outcome variable is truly discrete; if the categories would represent a binned discretization of an underlying continuous variable  a CDF representation is preferred.
+
+[^sample]: **Note on `sample` model output type**: Depending on the Hub specification, samples with the same sample index (specified by the `output_type_id`) may be assumed to correspond to a single sample from a joint distribution across multiple levels of the task id variables. This is discussed more below.
+
+[^cdf]: **Note on `cdf` model output type** and `pmf` output type for ordinal variables: In the hub's `tasks.json` configuration file, the values of the `output_type_id` should be listed in order from low to high.
 
 We emphasize that the `mean`, `median`, `quantile`, `cdf`, and `pmf` representations all summarize the marginal predictive distribution for a single combination of model task id variables. On the other hand, the `sample` representation may capture dependence across combinations of multiple model task id variables by recording samples from a joint predictive distribution. For example, suppose that the model task id variables are “forecast date”, “location” and “horizon”. A predictive mean will summarize the predictive distribution for a single combination of forecast date, location and horizon. On the other hand, there are several options for the distribution from which a sample might be drawn, capturing dependence across different levels of the task id variables, including:
 1. the joint predictive distribution across all locations and horizons within each forecast date
@@ -113,6 +107,7 @@ Validation of forecast values occurs in two steps:
    2. The probabilities assigned to bins must be non-negative and must sum to 1 within each model task, up to some specified tolerance.
 
 ## File formats
+
 * Considerations about `csv`:
    1. Some projects have run into 100 MB file size limits when using csv formatted files.
 * Considerations about `parquet`:
@@ -126,16 +121,30 @@ Validation of forecast values occurs in two steps:
 (model-output-schema)=
 ## The importance of a stable model output file schema
 
-> Note the difference in the following discussion between [hubverse schema](https://github.com/hubverse-org/schemas) - the schema which hub config files are validated against - and [`arrow schema`](https://arrow.apache.org/docs/11.0/r/reference/Schema.html) - the mapping of model output columns to data types.
+:::{note}
+The following discussion addresses two different types of schemas:
+ - [hubverse schema](https://github.com/hubverse-org/schemas)---the schema for **validating hub configuration files**
+ - [arrow schema](https://arrow.apache.org/docs/11.0/r/reference/Schema.html)---the schema for **model output columns in parquet files[^csv]**
+:::
 
-Because we store model output data as separate files but open them as a single [`arrow` dataset](https://arrow.apache.org/docs/r/reference/Dataset.html) using the `hubData` package, for a hub to be [successfully accessed and fully queryable across all columns as an `arrow dataset`](https://arrow.apache.org/docs/r/articles/dataset.html), it is necesssary to ensure that all files conform to the same [`arrow schema`](https://arrow.apache.org/docs/11.0/r/reference/Schema.html) (i.e. share the same column data types) across the lifetime of the hub. This means that additions of new rounds should not change the overall hub schema at a later date (i.e. after submissions have already started being collected). 
+[^csv]: This section is primarily a concern for parquet files, which encapsulate a schema within the file, but the broader issues have consequences for all output filetypes.
 
-Many common task IDs are covered by the [hubverse schema](#model-tasks-tasks-json-interactive-schema), are validated during hub config validation and should therefore have consistent and stable data types. However, there are a number of situations where a single consistent data type cannot be guaranteed, e.g.:
+Model output data are stored as separate files, but we use the `hubData` package to open them as a single [arrow dataset](https://arrow.apache.org/docs/r/reference/Dataset.html).
+**It is necesssary to ensure that all files conform to the same arrow schema** (i.e. share the same column data types) across the lifetime of the hub.
+When we know that all data types conform to the arrow schema, we can be sure that a hub can be [successfully accessed and fully queryable across all columns as an arrow dataset](https://arrow.apache.org/docs/r/articles/dataset.html)
+This means that **additions of new rounds _should not_ change the overall hub schema at a later date** (i.e. after submissions have already started being collected). 
+
+Many common task IDs should have consistent and stable data types because they are validated during hub configuration.
+However, there are a number of situations where a single consistent data type cannot be guaranteed, e.g.:
 - New rounds introducing changes in custom task ID value data types, which are not covered by the hubverse schema. 
 - New rounds introducing changes in task IDs covered by the schema but which accept multiple data types (e.g. `scenario_id` where both `integer` and `character` are accepted or `age_group` where no data type is specified in the hubverse schema).
 - Adding new output types, which might introduce `output_type_id` values of a new data type.
 
-While validation of config files will alert hub administrations to discrepancies in task ID value data types across modeling tasks and rounds, any changes to a hub's config which has the potential to change the overall data type of model output columns after submissions have been collected could cause issues downstream and should be avoided. These issues can range from data type casting being required in downstream analysis code that used to work, not being able to filter on columns with data type discrepancies between files before collecting to an inability to open hub model output data as an `arrow` dataset. They are primarily a problem for parquet files, which encapsulate a schema within the file, but have a small chance to cause parsing errors in csvs too.
+While validation of config files will alert hub administrations to discrepancies in task ID value data types across modeling tasks and rounds, modifications that will change the overall data type of model output columns _after submissions have been collected_ could cause downstream issues and _should be avoided_.
+Some examples of issues caused by a change in the overal data type of model output columns:
+ - data type casting being required in downstream analysis code that used to work, 
+ - not being able to filter on columns with data type discrepancies between files before collecting
+ - an inability to open hub model output data as an `arrow` dataset
 
 (output-type-id-datatype)=
 ### The `output_type_id` column data type

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -171,11 +171,7 @@ from the `hubValidations` R package, which performs two validation tasks:
 
 * Validation of more involved rules that cannot be encoded in a json schema are
   implemented separately (such as specific relationships between outputs and
-  targets). Examples of such rules include:
-   1. A predictive quantile for disease incidence may not be larger than the
-      population size in that location.
-   2. The probabilities assigned to bins must be non-negative and must sum to 1
-      within each model task, up to some specified tolerance.
+  targets). You can a table with the details of each check in [the `validate_submission()` documentation](https://hubverse-org.github.io/hubValidations/reference/validate_submission.html#details) and [the `validate_pr()` documentation](https://hubverse-org.github.io/hubValidations/reference/validate_pr.html#details).
 
 
 (model-output-schema)=

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -67,7 +67,7 @@ submission formats are _not mutuatlly exclusive_; **Hubs may choose between
 Much of the material in this section has been excerpted and/or adapted from the [hubEnsembles manuscript](https://github.com/hubverse-org/hubEnsemblesManuscript).[^Shandross-etal]
 ```
 
-[^Shandross-etal]: Shandross, L., Howerton, E., Contamin, L., Hochheiser, H., Krystalli, A., Consortium of Infectious Disease Modeling Hubs, Reich, N. G., Ray, E.L. (2024). [hubEnsembles: Ensembling Methods in R](https://github.com/hubverse-org/hubEnsemblesManuscript). *(under review for publication)*.
+[^Shandross-etal]: Shandross, L., Howerton, E., Contamin, L., Hochheiser, H., Krystalli, A., Consortium of Infectious Disease Modeling Hubs, Reich, N. G., Ray, E.L. (2024). [hubEnsembles: Ensembling Methods in R](https://www.medrxiv.org/content/10.1101/2024.06.24.24309416v1). *(under review for publication)* (Repo: https://github.com/hubverse-org/hubEnsemblesManuscript).
 
 _Model outputs are a specially formatted tabular representation of predictions._
 Each row corresponds to a single, unique prediction and each column provides information about what is being predicted, its scope, and its value. 
@@ -195,7 +195,7 @@ Model output data are stored as separate files, but we use the `hubData` package
 When we know that all data types conform to the arrow schema, we can be sure that a hub can be [successfully accessed and fully queryable across all columns as an arrow dataset](https://arrow.apache.org/docs/r/articles/dataset.html)
 This means that **additions of new rounds _should not_ change the overall hub schema at a later date** (i.e. after submissions have already started being collected). 
 
-[^troube]: Even if you do not use `hubData` to read model outputs, uniform schemas are still important if you want to join model output files and do analyses across submissions.
+[^trouble]: Even if you do not use `hubData` to read model outputs, uniform schemas are still important if you want to join model output files and do analyses across submissions.
 
 Many common task IDs should have consistent and stable data types because they are validated during hub configuration.
 However, there are a number of situations where a single consistent data type cannot be guaranteed, e.g.:

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -15,98 +15,36 @@ where `model_id` = `team_abbr-model_abbr`
 
 Note that file names are also allowed to contain the following compression extension prefixes: .snappy, .gzip, .gz, .brotli, .zstd, .lz4, .lzo, .bz2, e.g. `<round-id1>-<model_id>.gz.parquet`.
 
-(model-output-format)=
-## Formats of model output
+(model-output-example-table)=
+### Example model submission file
 
-```{admonition} Reference
-Much of the material in this section has been excerpted and/or adapted from the [hubEnsembles manuscript](https://github.com/hubverse-org/hubEnsemblesManuscript).[^Shandross-etal]
-```
+Each model submission file will have the same representation for each hub. Here
+is an example for a Hub that collects mean and quantile forecasts for
+one-week-ahead incidence, but probabilities for the timing of a season peak:  
 
-[^Shandross-etal]: Shandross, L., Howerton, E., Contamin, L., Hochheiser, H., Krystalli, A., Consortium of Infectious Disease Modeling Hubs, Reich, N. G., Ray, E.L. (2024). [hubEnsembles: Ensembling Methods in R](https://github.com/hubverse-org/hubEnsemblesManuscript). *(under review for publication)*.
+:::{table} An example of a model output submission for modelA
+| `model_id` | `origin_epiweek` | `target` | `horizon` | `output_type` | `output_type_id` | `value` |
+| ---------- | ------ | ------ | ------ | ------ | ------ | ------ | 
+| modelA | EW202242 | weekly rate | 1 | mean     | NA | 5 |
+| modelA | EW202242 | weekly rate | 1 | quantile | 0.25 | 2 |
+| modelA | EW202242 | weekly rate | 1 | quantile | 0.5 | 3 |
+| modelA | EW202242 | weekly rate | 1 | quantile | 0.75 | 10 |
+| modelA | EW202242 | weekly rate | 1 | pmf | 0 | 0.1 |
+| modelA | EW202242 | weekly rate | 1 | pmf | 0.1 | 0.2 |
+| modelA | EW202242 | weekly rate | 1 | pmf | 0.2 | 0.7 |
+| modelA | EW202242 | peak week | NA | pmf | EW202240 | 0.001 |
+| modelA | EW202242 | peak week | NA | pmf | EW202241 | 0.002 |
+| modelA | EW202242 | ... | ... | ... | ... | ... |
+| modelA | EW202242 | peak week | NA | pmf | EW202320 | 0.013 |
+| modelA | EW202242 | weekly rate | 1 | sample | 1 | 3 |
+| modelA | EW202242 | weekly rate | 1 | sample | 2 | 3 |
+:::
 
-Model outputs are a specially formatted tabular representation of predictions. Each row corresponds to a single, unique prediction and each column provides information about what is being predicted, its scope, and its value. Per hubverse convention, there are three groups of columns, each group serving a specific purpose: (1) the "model ID" denotes which model has produced the prediction, (2) the "task IDs" provide details about what is being predicted, and (3) the "model output representation" specifies how the prediction is represented. More detail about each of these is given in the following points:  
+### File formats
 
-   1. Each model should have a unique identifier that is stored in the `model-id` column.
-   2. The details of the outcome (the model task) are provided by the modeler, and can be stored in a series of "task ID" columns as described [in this section on task ID variables](#task-id-vars). These "task ID" columns may also include additional information, such as any conditions or assumptions that were used to generate the predictions. Some example variables include `target`, `location`, `reference_date`, and `horizon`. Although there are no restrictions on naming task ID variables, when appropriate, we suggest that Hubs adopt the standard task ID or column names and definitions specified [in the section on usage of task ID variables](#task-id-use).  
-   3. "Model output representation" consists of a set of three columns specifying how the model outputs are represented. All three of these columns will be used by all Hubs:  
-      1. `output_type` specifies the type of representation of the predictive distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`, `"pmf"`, or `"sample"`.  
-      2. `output_type_id` specifies more identifying information specific to the output type.  
-      3. `value` contains the model’s prediction.  
-     
-The following table provides examples that better explain how the "model output representation" columns are used:  
-
-(output-type-table)=
-| `output_type` | `output_type_id` | `value` |
-| ------ | ------ | ------ | 
-| `mean` | NA (not used for mean predictions) | Numeric: the mean of the predictive distribution |
-| `median` | NA (not used for median predictions) | Numeric: the median of the predictive distribution |
-| `quantile` | Numeric between 0.0 and 1.0: a probability level | Numeric: the quantile of the predictive distribution at the probability level specified by the output_type_id |
-| `cdf`[^cdf] | String or numeric: a possible value of the target variable | Numeric between 0.0 and 1.0: the value of the cumulative distribution function of the predictive distribution at the value of the outcome variable specified by the output_type_id |
-| `pmf`[^pmf] | String naming a possible category of a discrete outcome variable | Numeric between 0.0 and 1.0: the value of the probability mass function of the predictive distribution when evaluated at a specified level of a categorical outcome variable.[^cdf] |
-| `sample`[^sample] | Positive integer sample index | Numeric: a sample from the predictive distribution.
-
-
-[^pmf]: **Note on `pmf` model output type**: Values are required to sum to 1 across all `output_type_id` values within each combination of values of task id variables. This representation should only be used if the outcome variable is truly discrete; if the categories would represent a binned discretization of an underlying continuous variable  a CDF representation is preferred.
-
-[^sample]: **Note on `sample` model output type**: Depending on the Hub specification, samples with the same sample index (specified by the `output_type_id`) may be assumed to correspond to a single sample from a joint distribution across multiple levels of the task id variables. This is discussed more below.
-
-[^cdf]: **Note on `cdf` model output type** and `pmf` output type for ordinal variables: In the hub's `tasks.json` configuration file, the values of the `output_type_id` should be listed in order from low to high.
-
-We emphasize that the `mean`, `median`, `quantile`, `cdf`, and `pmf` representations all summarize the marginal predictive distribution for a single combination of model task id variables. On the other hand, the `sample` representation may capture dependence across combinations of multiple model task id variables by recording samples from a joint predictive distribution. For example, suppose that the model task id variables are “forecast date”, “location” and “horizon”. A predictive mean will summarize the predictive distribution for a single combination of forecast date, location and horizon. On the other hand, there are several options for the distribution from which a sample might be drawn, capturing dependence across different levels of the task id variables, including:
-1. the joint predictive distribution across all locations and horizons within each forecast date
-2. the joint predictive distribution across all horizons within each forecast date and location
-3. the joint predictive distribution across all locations within each forecast date and horizon
-4. the marginal predictive distribution for each combination of forecast date, location, and horizon
-
-Hubs should specify the collection of task id variables for which samples are expected to capture dependence; e.g., the first option listed above might specify that samples should be drawn from distributions that are “joint across” locations and horizons.  
-
-More details about sample-output-type can be found in [the page describing sample output type data](../user-guide/sample-output-type.md).
-Here is an example for a Hub that collects mean and quantile forecasts for one-week-ahead incidence, but probabilities for the timing of a season peak:  
-
-
-| `origin_epiweek` | `target` | `horizon` | `output_type` | `output_type_id` | `value` |
-| ------ | ------ | ------ | ------ | ------ | ------ | 
-| EW202242 | weekly rate | 1 | mean     | NA | 5 |
-| EW202242 | weekly rate | 1 | quantile | 0.25 | 2 |
-| EW202242 | weekly rate | 1 | quantile | 0.5 | 3 |
-| EW202242 | weekly rate | 1 | quantile | 0.75 | 10 |
-| EW202242 | weekly rate | 1 | pmf | 0 | 0.1 |
-| EW202242 | weekly rate | 1 | pmf | 0.1 | 0.2 |
-| EW202242 | weekly rate | 1 | pmf | 0.2 | 0.7 |
-| EW202242 | peak week | NA | pmf | EW202240 | 0.001 |
-| EW202242 | peak week | NA | pmf | EW202241 | 0.002 |
-| EW202242 | ... | ... | ... | ... | ... |
-| EW202242 | peak week | NA | pmf | EW202320 | 0.013 |
-| EW202242 | weekly rate | 1 | sample | 1 | 3 |
-| EW202242 | weekly rate | 1 | sample | 2 | 3 |
-
-We will develop tools that support multiple formats for the submissions, including csv, zipped csv, and parquet. Initial data loading functions will load data and return standard data output types for each language (e.g. data frames).
-
-
-## Other output types
-Some other possible model output representations have been proposed, but are not included on the list above. We document these other proposals and the reasons for their omissions here:
-
-* Other output types of point forecasts.  
-* Bin probability. Two notes:
-   * If the bins have open left endpoints and closed right endpoints, bin probabilities can be calculated directly from CDF values.
-   * We considered a system with a more flexible specification of bin endpoint inclusion status, but noted two disadvantages:
-      * This additional flexibility would introduce substantial extra complexity to the metadata specifications and tooling
-      * It might be beneficial to adopt limited standards that encourage Hubs to adopt settings that are consistent with the common definitions. For example, if a Hub were to adopt bins with open right endpoints, the resulting probabilities would be incompatible with the conventions around cumulative distribution functions.
-* Probability of “success” in a setting with a binary outcome
-   * This can be captured with a CDF representation if the outcome variable is ordered, or a categorical representation if the outcome variable is not ordered.
-* Compositional. For example, we might request a probabilistic forecast of the proportion of hospitalizations next week that are due to influenza A/H1, A/H3, and B.
-   * Note that if only point forecasts for the composition were required, a categorical output representation could be used.
-
-## Validating forecast values
-Validation of forecast values occurs in two steps:
-
-* The data output types and relatively simple limits on values are specified in a json schema file. For example, if appropriate, we might specify that the value is a non-negative integer.
-
-* Validation of more involved rules that cannot be encoded in a json schema are implemented separately. Examples of such rules include:
-   1. A predictive quantile for disease incidence may not be larger than the population size in that location.
-   2. The probabilities assigned to bins must be non-negative and must sum to 1 within each model task, up to some specified tolerance.
-
-## File formats
+Hubs can take submissions in tabular data formats, namely CSV and parquet. Hubs
+can be set up to take either or both if necessary. Both have advantages and
+tradeoffs:
 
 * Considerations about `csv`:
    1. Some projects have run into 100 MB file size limits when using csv formatted files.
@@ -118,14 +56,133 @@ Validation of forecast values occurs in two steps:
    * Disadvantages:
       * Harder to work with; teams and people who want to work with files need to install additional libraries
 
+
+(model-output-format)=
+## Formats of model output
+
+```{admonition} Reference
+Much of the material in this section has been excerpted and/or adapted from the [hubEnsembles manuscript](https://github.com/hubverse-org/hubEnsemblesManuscript).[^Shandross-etal]
+```
+
+[^Shandross-etal]: Shandross, L., Howerton, E., Contamin, L., Hochheiser, H., Krystalli, A., Consortium of Infectious Disease Modeling Hubs, Reich, N. G., Ray, E.L. (2024). [hubEnsembles: Ensembling Methods in R](https://github.com/hubverse-org/hubEnsemblesManuscript). *(under review for publication)*.
+
+_Model outputs are a specially formatted tabular representation of predictions._
+Each row corresponds to a single, unique prediction and each column provides information about what is being predicted, its scope, and its value. 
+Per hubverse convention, **there are three groups of columns**, each group serving a specific purpose: (1) the **"model ID"** is a single column that denotes which model has produced the prediction, (2) the **"task ID"** columns provide details about what is being predicted, and (3) the three **"model output representation"** columns specifies the type of prediction, identifying information about that prediction, and the value of the prediction. 
+
+As shown in [the model output submission table](#model-output-example-table) above, the
+**"model ID"** is in the `model_id` column; there are 3 **"task ID"** columns: `origin_epiweek`, `target`, and `horizon`; and finally there are three **"model output representation"** columns: `output_type`, `output_type_id`, and `value`. More detail about each of these column groups is given in the following points:  
+
+   1. **"Model ID" (1 column)**: Each model should have a unique identifier
+      that is stored in the `model-id` column.
+   2. **"Task IDs" (multiple columns)**:  The details of the outcome (the model
+      task) are provided by the modeler, and can be stored in a series of "task
+      ID" columns as described [in this section on task ID
+      variables](#task-id-vars). These "task ID" columns may also include
+      additional information, such as any conditions or assumptions that were
+      used to generate the predictions. Some example variables include
+      `target`, `location`, `reference_date`, and `horizon`.    Although there
+      are no restrictions on naming task ID variables, when appropriate, we
+      suggest that Hubs adopt the standard task ID or column names and
+      definitions specified [in the section on usage of task ID
+      variables](#task-id-use).  
+   3. **"Model output representation" (3 columns)**: consists of a set of three
+      columns specifying how the model outputs are represented. All three of
+      these columns will be used by all Hubs:  
+      1. `output_type` specifies the type of representation of the predictive
+         distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`,
+         `"cmf"`, `"pmf"`, or `"sample"`.  
+      2. `output_type_id` specifies more identifying information specific to
+         the output type, which varies depending on the `output_type`
+      3. `value` contains the model’s prediction.  
+
+
+The following table provides examples that better explain how the "model output representation" columns are used:  
+
+(output-type-table)=
+:::{table} Relationship between the three model output representation columns with respect to the type of prediction (`output_type`)
+| `output_type` | `output_type_id` | `value` |
+| ------ | ------ | ------ | 
+| `mean` | `"NA"`[^batman] (not used for mean predictions) | Numeric: the mean of the predictive distribution |
+| `median` | `"NA"` (not used for median predictions) | Numeric: the median of the predictive distribution |
+| `quantile` | Numeric between 0.0 and 1.0: a probability level | Numeric: the quantile of the predictive distribution at the probability level specified by the output_type_id |
+| `cdf`[^cdf] | String or numeric: a possible value of the target variable | Numeric between 0.0 and 1.0: the value of the cumulative distribution function of the predictive distribution at the value of the outcome variable specified by the output_type_id |
+| `pmf`[^pmf] | String naming a possible category of a discrete outcome variable | Numeric between 0.0 and 1.0: the value of the probability mass function of the predictive distribution when evaluated at a specified level of a categorical outcome variable.[^cdf] |
+| `sample`[^sample] | Positive integer sample index | Numeric: a sample from the predictive distribution.
+:::
+
+
+[^batman]: Why have `"NA"` as the `output_type_id`? There are two reasons for this. 
+  The first is that this provides a placeholder for the model output CSV file in the presence of other output types for validation.
+  The second reason is because we already use `null` to indicate the presence of an absence in the `required` and `optional` fields and having this allows hubverse tools to treat point esitmates without special handling. 
+
+[^pmf]: **Note on `pmf` model output type**: Values are required to sum to 1 across all `output_type_id` values within each combination of values of task id variables. This representation should only be used if the outcome variable is truly discrete; if the categories would represent a binned discretization of an underlying continuous variable  a CDF representation is preferred.
+
+[^sample]: **Note on `sample` model output type**: Depending on the Hub specification, samples with the same sample index (specified by the `output_type_id`) may be assumed to correspond to a single sample from a joint distribution across multiple levels of the task id variables. This is discussed more below.
+
+[^cdf]: **Note on `cdf` model output type** and `pmf` output type for ordinal variables: In the hub's `tasks.json` configuration file, the values of the `output_type_id` should be listed in order from low to high.
+
+
+(model-output-task-relationship)=
+## Model output relationships to task ID variables
+
+We emphasize that the `mean`, `median`, `quantile`, `cdf`, and `pmf` representations all **summarize the marginal predictive distribution for a single combination of model task id variables**. 
+In contrast, we cannot assume the same for the `sample` representation.
+By recording samples from a joint predictive distribution, **the `sample` representation may capture dependence across combinations of multiple model task id variables**.
+
+For example, suppose that the model task id variables are “forecast date”, “location” and “horizon”. 
+A predictive mean will summarize the predictive distribution for a single combination of forecast date, location and horizon. On the other hand, there are several options for the distribution from which a sample might be drawn, capturing dependence across different levels of the task id variables, including:
+1. the joint predictive distribution across all locations and horizons within each forecast date
+2. the joint predictive distribution across all horizons within each forecast date and location
+3. the joint predictive distribution across all locations within each forecast date and horizon
+4. the marginal predictive distribution for each combination of forecast date, location, and horizon
+
+Hubs should specify the collection of task id variables for which samples are expected to capture dependence; e.g., the first option listed above might specify that samples should be drawn from distributions that are “joint across” locations and horizons.  
+
+More details about sample-output-type can be found in [the page describing sample output type data](../user-guide/sample-output-type.md).
+
+### Omitted output types
+
+Some other possible model output representations have been proposed, but are not included on the list above. We document these other proposals and the reasons for their omissions here:
+
+#### Point forecasts
+
+* Bin probability. Two notes:
+   * If the bins have open left endpoints and closed right endpoints, bin probabilities can be calculated directly from CDF values.
+   * We considered a system with a more flexible specification of bin endpoint inclusion status, but noted two disadvantages:
+      * This additional flexibility would introduce substantial extra complexity to the metadata specifications and tooling
+      * It might be beneficial to adopt limited standards that encourage Hubs to adopt settings that are consistent with the common definitions. For example, if a Hub were to adopt bins with open right endpoints, the resulting probabilities would be incompatible with the conventions around cumulative distribution functions.
+* Probability of “success” in a setting with a binary outcome
+   * This can be captured with a CDF representation if the outcome variable is ordered, or a categorical representation if the outcome variable is not ordered.
+* Compositional. For example, we might request a probabilistic forecast of the proportion of hospitalizations next week that are due to influenza A/H1, A/H3, and B.
+   * Note that if only point forecasts for the composition were required, a categorical output representation could be used.
+
+## Validating forecast values
+
+Validation of forecast submissions is done with the function 
+[`validate_submissions()`](https://hubverse-org.github.io/hubValidations/reference/validate_submission.html)
+from the `hubValidations` R package, which performs two validation tasks:
+
+* Validation based on rules that can easily be encoded in the JSON schema such as
+  ranges of expected values and `output_type_id`s. 
+
+* Validation of more involved rules that cannot be encoded in a json schema are
+  implemented separately (such as specific relationships between outputs and
+  targets). Examples of such rules include:
+   1. A predictive quantile for disease incidence may not be larger than the
+      population size in that location.
+   2. The probabilities assigned to bins must be non-negative and must sum to 1
+      within each model task, up to some specified tolerance.
+
+
 (model-output-schema)=
 ## The importance of a stable model output file schema
 
-:::{note}
+```{admonition} NOTE
 The following discussion addresses two different types of schemas:
  - [hubverse schema](https://github.com/hubverse-org/schemas)---the schema for **validating hub configuration files**
- - [arrow schema](https://arrow.apache.org/docs/11.0/r/reference/Schema.html)---the schema for **model output columns in parquet files[^csv]**
-:::
+ - [arrow schema](https://arrow.apache.org/docs/11.0/r/reference/Schema.html)---the schema for **model output columns in parquet files**[^csv]
+```
 
 [^csv]: This section is primarily a concern for parquet files, which encapsulate a schema within the file, but the broader issues have consequences for all output filetypes.
 

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -187,10 +187,12 @@ This section is primarily a concern for parquet files, which encapsulate a schem
 ```
 
 
-Model output data are stored as separate files, but we use the `hubData` package to open them as a single [arrow dataset](https://arrow.apache.org/docs/r/reference/Dataset.html).
+Model output data are stored as separate files, but we use the `hubData` package to open them as a single [arrow dataset](https://arrow.apache.org/docs/r/reference/Dataset.html).[^trouble]
 **It is necesssary to ensure that all files conform to the same arrow schema** (i.e. share the same column data types) across the lifetime of the hub.
 When we know that all data types conform to the arrow schema, we can be sure that a hub can be [successfully accessed and fully queryable across all columns as an arrow dataset](https://arrow.apache.org/docs/r/articles/dataset.html)
 This means that **additions of new rounds _should not_ change the overall hub schema at a later date** (i.e. after submissions have already started being collected). 
+
+[^troube]: Even if you do not use `hubData` to read model outputs, uniform schemas are still important if you want to join model output files and do analyses across submissions.
 
 Many common task IDs should have consistent and stable data types because they are validated during hub configuration.
 However, there are a number of situations where a single consistent data type cannot be guaranteed, e.g.:
@@ -202,7 +204,7 @@ While validation of config files will alert hub administrations to discrepancies
 Some examples of issues caused by a change in the overal data type of model output columns:
  - data type casting being required in downstream analysis code that used to work, 
  - not being able to filter on columns with data type discrepancies between files before collecting
- - an inability to open hub model output data as an `arrow` dataset
+ - errors when opening hub model output data with popular analytics tools like arrow, pandas, and polars
 
 (output-type-id-datatype)=
 ### The `output_type_id` column data type


### PR DESCRIPTION
The model output chapter felt like there were unfinished parts to it, so I did my best to finish it. It is at a point where I am comfortable with a review. 

This rearranges and modifies the model-output page in the following ways:

 - moved example table to the top as subsection of directory structure
 - removed language about plans for developing tools
 - moved file formats as subsection of directory structure
 - clarified the three types of columns in the Formats of
   model output section
 - added copious footnotes for the output type table
 - added captions for the tables
 - changed "other output types" to "omitted output types" and made it a
   subsection
 - added text to the validating forecast values section, pointing to
   `validate_submissions()`, but I am not sure if this is correct.
 - made the note of stable model output file schema an admonition
 - clarified the relationship between hubverse schema and arrow schema

## Analysis

I think this page is missing an explicit connection between the model output table and the JSON schema. Right now, there is a lot of discussion about the representation of the output types and it bounces from detailed to broad and back to detailed. Much of the discussion is relevant for both modelers and admins, but it seems like the last section is largely relevant for admins. 

It might be a good idea to have small snippets of config files that demonstrate the relationships and to more clearly separate the admin concerns. 