### PR TITLE
Add mention of "model_output_dir" key in documentation; fix broken crossrefs

### DIFF
--- a/docs/source/overview/who-uses-hubverse.md
+++ b/docs/source/overview/who-uses-hubverse.md
@@ -36,7 +36,7 @@ They will be validated on submission.
 
 As a modeler, you will need to
 
- - understand the definitions of and differences between [model output types](/user-guide/model-output.md#formats-of-model-output)
+ - understand the definitions of and differences between [model output types](#model-output-format)
  - understand the [structure of model output datasets](https://hubverse-org.github.io/hubData/articles/connect_hub.html#structure-of-hubverse-datasets)
  - build ensembles using the [`{hubEnsembles}` R package](https://hubverse-org.github.io/hubEnsembles).
 

--- a/docs/source/user-guide/hub-structure.md
+++ b/docs/source/user-guide/hub-structure.md
@@ -8,7 +8,7 @@ A hub repository should be structured according to the following guidelines:
 it should be moved to another repository. 
 
 [^model-output]: The directory is required, but the name is flexible. You can
-  use a custom directory path by setting the `"model_output_dir"` key in the
+  use a custom directory path by setting the `"model_output_dir"` property in the
   `admin.json` file. More details can be found in the `admin.json` schema
   definition.
 

--- a/docs/source/user-guide/hub-structure.md
+++ b/docs/source/user-guide/hub-structure.md
@@ -2,11 +2,15 @@
 
 A hub repository should be structured according to the following guidelines:
 
-1. Code and scripts must not be present in the `model-output` directory of a hub repository.
+1. Code and scripts must not be present in the `model-output`[^model-output] directory of a hub repository.
 2. If code is included in the hub repository, it should live in a centrally located directory, which we recommend naming `src`.
 3. If code has the potential to disrupt or break other continuous integration operations in the hub (e.g., validation of incoming submissions),
 it should be moved to another repository. 
 
+[^model-output]: The directory is required, but the name is flexible. You can
+  use a custom directory path by setting the `"model_output_dir"` key in the
+  `admin.json` file. More details can be found in the `admin.json` schema
+  definition.
 
 The directory and file structure of a modeling hub should contain only the following directories, subdirectories, and files:
 

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -1,7 +1,8 @@
 # Model output
 
 ## Directory structure
-The `model-output` directory in a modeling hub is required to have the following subdirectory and file structure:
+
+The `model-output`[^model-output] directory in a modeling hub is required to have the following subdirectory and file structure:
 
 * `team1-modelA`
    * `<round-id1>-<model_id>.csv` (or parquet, etc)
@@ -14,6 +15,11 @@ The `model-output` directory in a modeling hub is required to have the following
 where `model_id` = `team_abbr-model_abbr`
 
 Note that file names are also allowed to contain the following compression extension prefixes: .snappy, .gzip, .gz, .brotli, .zstd, .lz4, .lzo, .bz2, e.g. `<round-id1>-<model_id>.gz.parquet`.
+
+[^model-output]: The directory is required, but the name is flexible. You can
+    use a custom directory path by setting the `"model_output_dir"` key in the
+    `admin.json` file. More details can be found in the `admin.json` schema
+    definition
 
 (model-output-example-table)=
 ### Example model submission file

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -46,6 +46,7 @@ one-week-ahead incidence, but probabilities for the timing of a season peak:
 | EW202242 | weekly rate | 1 | sample | 2 | 3 |
 :::
 
+(formats-of-model-output)=
 ### File formats
 
 Hubs can take submissions in tabular data formats, namely `csv` and `parquet`. These
@@ -200,7 +201,7 @@ This means that **additions of new rounds _should not_ change the overall hub sc
 
 [^trouble]: Even if you do not use `hubData` to read model outputs, uniform schemas are still important if you want to join model output files and do analyses across submissions.
 
-Many common task IDs should have consistent and stable data types because they are validated against [the task IDs in the hubverse schema](#model-tasks-tasks-json-interactive-schema) during model submission.
+Many common task IDs should have consistent and stable data types because they are validated against [the task IDs in the hubverse schema](#model-tasks-schema) during model submission.
 However, there are a number of situations where a single consistent data type cannot be guaranteed, e.g.:
 - New rounds introducing changes in custom task ID value data types, which are not covered by the hubverse schema. 
 - New rounds introducing changes in task IDs covered by the schema but which accept multiple data types (e.g. `scenario_id` where both `integer` and `character` are accepted or `age_group` where no data type is specified in the hubverse schema).

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -17,7 +17,7 @@ where `model_id` = `team_abbr-model_abbr`
 Note that file names are also allowed to contain the following compression extension prefixes: .snappy, .gzip, .gz, .brotli, .zstd, .lz4, .lzo, .bz2, e.g. `<round-id1>-<model_id>.gz.parquet`.
 
 [^model-output]: The directory is required, but the name is flexible. You can
-    use a custom directory path by setting the `"model_output_dir"` key in the
+    use a custom directory path by setting the `"model_output_dir"` property in the
     `admin.json` file. More details can be found in the `admin.json` schema
     definition
 

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -12,12 +12,12 @@ The three components of modeling tasks are:
  - The [`task_ids`{.codeitem} object](#task-id-vars) defines both labels for columns in submission files and the set of valid values for each column.
    Any unique combination of the values define a single modeling task, or target. 
  - The [`output_type`{.codeitem} object](#output-types) defines accepted representations _for each task_.
-   More on the different output types can be found in [The Model Output Chapter](model-output.md#formats-of-model-output).
+   More on the different output types can be found in [The Model Output Chapter](#formats-of-model-output).
  - The [`target_metadata`{.codeitem} array](#target-metadata) provides additional information about each target.
 
 [^json]: Due to technical issues, we do not currently support [json references](http://niem.github.io/json/reference/json-schema/references/) or yaml metadata files.
 
-[^multiround]: For multiple rounds to share the same tasks without duplicating the `model_tasks` block, `round_id_from_variable` can be set to `true` and the `round_id` should be a column defined in the `task_ids`. See [the `tasks.json` schema](hub-config.md#hub-model-task-configuration-tasks-json-file) for details.
+[^multiround]: For multiple rounds to share the same tasks without duplicating the `model_tasks` block, `round_id_from_variable` can be set to `true` and the `round_id` should be a column defined in the `task_ids`. See [the `tasks.json` schema](#tasks-metadata) for details.
 
 
 (task-id-vars)=


### PR DESCRIPTION
This adds a sidetone about "model_output_dir" in two places that mention `model-output` to fix #187 

Requesting a review from @mmkerr because she's working on the manuscript and I want to make sure this is accurate.

Also requesting a review from @matthewcornell who requested the change and @annakrystalli who knows the most about this specification. 


As a side note, I would have linked directly to the admin.json section in the sidenote, but Sphinx was deciding to be difficult about it:

<details>
<summary>Sphinx being annoying</summary>

```
12:41:18 ~/path/to/hubDocs/docs
(znk/document-model-output/187)$ make html
Running Sphinx v7.1.2
[autosummary] generating autosummary for: coc/committee.md, coc/covenant.md, coc/enforcement-manual.md, index.md, overview/cite.md, overview/contact.md, overview/contribute.md, overview/data-storage.md, overview/definitions.md, overview/history.md, ..., user-guide/hub-structure.md, user-guide/intro-data-formats.md, user-guide/model-abstracts.md, user-guide/model-metadata.md, user-guide/model-output.md, user-guide/presentations.md, user-guide/sample-output-type.md, user-guide/software.md, user-guide/target-data.md, user-guide/tasks.md
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://www.sphinx-doc.org/en/master/objects.inv...
myst v4.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'substitution', 'attrs_inline', 'deflist', 'amsmath', 'tasklist', 'colon_fence', 'dollarmath', 'fieldlist'}, disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={schema_version: ..., schema_branch: ...}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 33 source files that are out of date
updating environment: [new config] 33 added, 0 changed, 0 removed
reading sources... [100%] user-guide/tasks
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
                  copying downloadable files... [100%] files/202311-ecdc-hub-launch.pdf
copying static files... done
copying extra files... done
done
/path/to/hubverse-org/hubDocs/docs/source/quickstart-hub-admin/tasks-config.md:257: WARNING: Could not lex literal_block '{\n  "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json",\n  "rounds": [...],\n  "output_type_id_datatype": "character"\n}\n' as "json". Highlighting skipped.
/path/to/hubverse-org/hubDocs/docs/source/user-guide/hub-structure.md:10: WARNING: local id not found in doc 'user-guide/hub-config': 'hub-admin-config'
/path/to/hubverse-org/hubDocs/docs/source/user-guide/hub-structure.md:10: WARNING: local id not found in doc 'user-guide/hub-config': 'hub-admin-config'

====================== slowest reading durations =======================
0.066 user-guide/sample-output-type
0.055 user-guide/model-output
0.034 quickstart-hub-admin/tasks-config
0.024 user-guide/tasks
0.016 coc/covenant

Exception occurred:
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/docutils/nodes.py", line 741, in index
    return self.children.index(item, start, stop)
ValueError: <pending_xref: <inline...>> is not in list
The full traceback has been saved in /var/folders/9p/m996p3_55hjf1hc62552cqfr0000gr/T/sphinx-err-72_s488l.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [html] Error 2
```

The error log is as follows. I'm not going to report it because I don't want to go through the process of creating a reproducible example of a sphinx site and I don't want to get yelled at for giving the maintainers a whole-ass repository. 

```
# Platform:         darwin; (macOS-14.6.1-arm64-arm-64bit)
# Sphinx version:   7.1.2
# Python version:   3.10.14 (CPython)
# Docutils version: 0.19
# Jinja2 version:   3.1.2
# Pygments version: 2.15.1

# Last messages:
#   writing output... [ 73%]
#   user-guide/hub-structure
#   
#   
#   ====================== slowest reading durations =======================
#   0.066 user-guide/sample-output-type
#   0.055 user-guide/model-output
#   0.034 quickstart-hub-admin/tasks-config
#   0.024 user-guide/tasks
#   0.016 coc/covenant

# Loaded extensions:
#   sphinx.ext.mathjax (7.1.2)
#   alabaster (0.7.13)
#   sphinxcontrib.applehelp (1.0.4)
#   sphinxcontrib.devhelp (1.0.2)
#   sphinxcontrib.htmlhelp (2.0.1)
#   sphinxcontrib.serializinghtml (1.1.5)
#   sphinxcontrib.qthelp (1.0.3)
#   sphinx.ext.duration (7.1.2)
#   sphinx.ext.doctest (7.1.2)
#   sphinx.ext.autodoc.preserve_defaults (7.1.2)
#   sphinx.ext.autodoc.type_comment (7.1.2)
#   sphinx.ext.autodoc.typehints (7.1.2)
#   sphinx.ext.autodoc (7.1.2)
#   sphinx.ext.autosummary (7.1.2)
#   sphinx.ext.intersphinx (7.1.2)
#   myst_parser (4.0.0)
#   sphinx_design (0.6.0)
#   sphinxcontrib.mermaid (7.1.2)
#   sphinx_book_theme (unknown version)
#   pydata_sphinx_theme (unknown version)

# Traceback:
Traceback (most recent call last):
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/cmd/build.py", line 290, in build_main
    app.build(args.force_all, args.filenames)
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/application.py", line 351, in build
    self.builder.build_update()
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 290, in build_update
    self.build(to_build,
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 360, in build
    self.write(docnames, list(updated_docnames), method)
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 567, in write
    self._write_serial(sorted(docnames))
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 574, in _write_serial
    doctree = self.env.get_and_resolve_doctree(docname, self)
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/environment/__init__.py", line 624, in get_and_resolve_doctree
    self.apply_post_transforms(doctree, docname)
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/environment/__init__.py", line 670, in apply_post_transforms
    transformer.apply_transforms()
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/transforms/__init__.py", line 80, in apply_transforms
    super().apply_transforms()
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/docutils/transforms/__init__.py", line 173, in apply_transforms
    transform.apply(**kwargs)
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/transforms/post_transforms/__init__.py", line 37, in apply
    self.run(**kwargs)
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/sphinx/transforms/post_transforms/__init__.py", line 115, in run
    node.replace_self(newnodes)
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/docutils/nodes.py", line 1007, in replace_self
    self.parent.replace(self, new)
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/docutils/nodes.py", line 980, in replace
    index = self.index(old)
  File "/path/to/hubverse-org/hubDocs/.venv/lib/python3.10/site-packages/docutils/nodes.py", line 741, in index
    return self.children.index(item, start, stop)
ValueError: <pending_xref: <inline...>> is not in list

```

</details>