### PR TITLE
clarify missingness of point estimates; add examples for determining output_type_id format

### DIFF
--- a/docs/source/quickstart-hub-admin/tasks-config.md
+++ b/docs/source/quickstart-hub-admin/tasks-config.md
@@ -186,8 +186,10 @@ As seen previously, each `task_ids` has a `required` and an `optional` property 
 
 ### 6.1. Setting the `"mean"`:  
 - <mark style="background-color: #FFE331">Here, the `"mean"` of the predictive distribution</mark> is set as a valid value for a submission file.  
-- <mark style="background-color: #32E331">`"output_type_id"` is used</mark> to determine whether the `mean` is a required or an optional `output_type`. Both `"required"` and `"optional"` should be declared, and the option that is chosen (required or optional) should be set to `["NA"]`, whereas the one that is not selected should be set to `null`. In this example, the mean is optional, not required. If the mean is required, `"required"` should be set to `["NA"]`, and `"optional"` should be set to `null`.  
+- <mark style="background-color: #32E331">`"output_type_id"` is used</mark> to determine whether the `mean` is a required or an optional `output_type`. Both `"required"` and `"optional"` should be declared, and the option that is chosen (required or optional) should be set to `["NA"]`[^missy], whereas the one that is not selected should be set to `null`. In this example, the mean is optional, not required. If the mean is required, `"required"` should be set to `["NA"]`, and `"optional"` should be set to `null`.  
 - <mark style="background-color: #38C7ED">`"value"` sets the characteristics</mark> of this valid `output_type` (i.e., the mean). In this instance, the value must be an `integer` greater than or equal to `0`.  
+
+[^missy]: `NA` (without quotes) is how missingness is represented in R. This notation may seem a bit strange, but it allows us to indicate what we expect to see from modeler submissions.
 
 ```{image} ../images/tasks-schema-6-1.png
 :alt: Some more lines of code in the tasks.json file

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -46,7 +46,9 @@ one-week-ahead incidence, but probabilities for the timing of a season peak:
 | EW202242 | weekly rate | 1 | sample | 2 | 3 |
 :::
 
-[^batman]: `NA` (without quotes) indicates missingness in R, which is the expected `output_type_id` for a `mean` `output_type`. 
+[^batman]: The `output_type_id` for point estimates (e.g. `mean`) is not applicable. To
+reflect this, we need to signal that this is a missing value. In R, missing values are
+encoded as `NA`, and in Python, they are encoded as `None`.
   This is discussed in the [output type table](#output-type-table)
 
 

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -101,12 +101,12 @@ specified in the [section on usage of task ID variables](#task-id-use) when appr
 2. **"Model output representation" (3 columns)**: consists of three
    columns specifying how the model outputs are represented. All three of these
    columns will be present in all model output data:
-  1. `output_type` specifies the type of representation of the predictive
-     distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`,
-     `"pmf"`, or `"sample"`.
-  2. `output_type_id` specifies more identifying information specific to the
-     output type, which varies depending on the `output_type`.
-  3. `value` contains the model’s prediction.
+   1. `output_type`{.codeitem} specifies the type of representation of the predictive
+      distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`,
+      `"pmf"`, or `"sample"`.
+   2. `output_type_id`{.codeitem} specifies more identifying information specific to the
+      output type, which varies depending on the `output_type`.
+   3. `value`{.codeitem} contains the model’s prediction.
 
 
 The following table provides more detail on how to configure the three "model output representation" columns based on each model output type.
@@ -123,7 +123,7 @@ The following table provides more detail on how to configure the three "model ou
 | `sample` | Positive integer sample index | Numeric: a sample from the predictive distribution.
 :::
 
-:::{note} Caveats for model `output_type_id`s
+:::{note} 
 :name: output-type-caveats
 
 The model output type ids have different caveats depending on the `output_type`:

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -47,7 +47,7 @@ one-week-ahead incidence, but probabilities for the timing of a season peak:
 :::
 
 [^batman]: `NA` (without quotes) indicates missingness in R, which is the expected `output_type_id` for a `mean` `output_type`. 
-  This is discussed in the [Output type table](#output-type-table)
+  This is discussed in the [output type table](#output-type-table)
 
 
 (file-formats)=
@@ -71,7 +71,7 @@ submission formats are _not mutually exclusive_; **hubs may choose between
       * Compatibility: Harder to work with; teams and people who want to work with files need to install additional libraries
 
 Examples of how to create these file formats in R and Python are listed below in
-[the Writing Model Output section](#writing-model-output).
+[the writing model output section](#writing-model-output).
 
 (formats-of-model-output)=
 ## Formats of model output
@@ -129,7 +129,7 @@ The following table provides more detail on how to configure the three "model ou
 :::{note} 
 :name: output-type-caveats
 
-The model output type ids have different caveats depending on the `output_type`:
+The model output type IDs have different caveats depending on the `output_type`:
 
 `mean` and `median`
 : Point estimates do not have an `output_type_id` because you can only have one
@@ -170,7 +170,7 @@ of writing model output to a hub in R and Python using parquet and CSV files.
 In these examples, we are assuming the following variables already exist:
 
  - `model_out_tbl` is the tabular output from your model formatted as specified
-   in [the Formats of Model Output section](#formats-of-model-output).
+   in [the formats of model output section](#formats-of-model-output).
  - `path_to_hub` is the path to the hub cloned on your local computer
  - `model_name` is the file name of your model formatted as
    `<round_id>-<model_name>.csv` (or parquet)
@@ -178,7 +178,7 @@ In these examples, we are assuming the following variables already exist:
 (example-csv)=
 ### Example: model output as CSV
 
-To write to CSV, you would use the `write_csv()` from the readr package in R and
+To write to CSV, you would use the `write_csv()` from the `readr` package in R and
 the `to_csv()` method in Python. 
 
 #### Writing CSV with R

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -91,7 +91,7 @@ Per hubverse convention, **there are two groups of columns providing metadata ab
 [^model-id]: When using models for downstream analysis with the [`collect_hub()` function](https://hubverse-org.github.io/hubData/reference/collect_hub.html) in the `hubData` package, one more column called `model_id` is prepended that identifies the model from its filename. 
 
 The model output follows the specification of the `tasks.json` configuration
-file of the hub. If you are creating a model and you would like to know what
+file of the hub. If you are creating a model and would like to know what
 data type your columns should be in, the hubVerse has utilities to provide and
 arrow schema and even a full submission template from the `tasks.json`
 configuration file. 
@@ -108,7 +108,7 @@ file](https://raw.githubusercontent.com/hubverse-org/example-simple-forecast-hub
 
 ```r
 # read the configuration file and get the latest round
-config_tasks <- hubData::read_config_file(tasks_path)
+config_tasks <- hubUtils::read_config_file(tasks_path)
 schema <- hubData::create_hub_schema(config_tasks)
 ```
 
@@ -141,11 +141,11 @@ file](https://raw.githubusercontent.com/hubverse-org/example-simple-forecast-hub
 
 ```r
 # read the configuration file and get the latest round
-config_tasks <- hubData::read_config_file(tasks_path)
-rounds <- hubData::get_round_ids(config_tasks)
+config_tasks <- hubUtils::read_config_file(tasks_path)
+rounds <- hubUtils::get_round_ids(config_tasks)
 this_round <- rounds[length(rounds)]
 # create the submission template (this may take some time if your submission uses samples)
-tmpl <- hubValidations::submission_tmpl(config_tasks, round_id = this_round)
+tmpl <- hubValidations::submission_tmpl(config_tasks = config_tasks, round_id = this_round)
 # write the template to a parquet file to use in your model code. 
 arrow::write_parquet(tmpl, "/path/to/template.parquet")
 ```
@@ -219,9 +219,9 @@ variables — further details are discussed below.
 ## Writing model output to a hub
 
 When submitting model output to a hub, it should be placed in a folder with the
-name of your model in the model outputs folder specified by the hub
-administrator (this is usually called `model-output`). Below are two examples
-of writing model output to a hub in R and Python using parquet and CSV files.
+name of your `model_id` in the model outputs folder specified by the hub
+administrator (this is usually called `model-output`). Below are R and Python examples
+for writing Hubverse-compliant model output files in both CSV and parquet format.
 In these examples, we are assuming the following variables already exist:
 
  - `model_out` is the tabular output from your model formatted as specified
@@ -229,16 +229,16 @@ In these examples, we are assuming the following variables already exist:
  - `hub_path` is the path to the hub cloned on your local computer
  - `model_id` is the combination of `<team_abbr>-<model_abbr>` 
  - `file_name` is the file name of your model formatted as
-   `<round_id>-<model_id>.csv` (or parquet)
+   `<round_id>-<model_id>.csv` (or `.parquet`)
 
 (example-csv)=
 ### Example: model output as CSV
 
-To write to CSV, you would use the `write_csv()` from the `readr` package in R and
-the `to_csv()` method in Python. 
+The sections below provide examples for writing CSV model output files that correctly encode missing data.
 
 #### Writing CSV with R
 
+When writing a model output file in R, use the `readr` package.
 ```r
 # ... generate model data ...
 outfile <- fs::path(hub_path, "model-output", model_id, file_name)
@@ -247,11 +247,12 @@ readr::write_csv(model_out, outfile)
 
 #### Writing CSV with Python
 
+Python users can use the `pandas` package when creating CSV model output files.
 ```python
 import pandas as pd
 import os.path
 # ... generate model data ...
-outfile = os.path.join(hub_path, "model-output", "team1-modelA", model_id)
+outfile = os.path.join(hub_path, "model-output", "team1-modelA", file_name)
 model_out.to_csv(outfile, index = False, na_rep = "NA")
 ```
 
@@ -280,7 +281,7 @@ arrow::write_parquet(model_out, outfile)
 import pandas as pd
 import os.path
 # ... generate model data ...
-outfile = os.path.join(hub_path, "model-output", "team1-modelA", model_id)
+outfile = os.path.join(hub_path, "model-output", "team1-modelA", file_name)
 model_out["output_type_id"] = model_out["output_type_id"].astype("string") # or "float", or "Int64"
 model_out.to_parquet(outfile)
 ```

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -88,7 +88,7 @@ _Model outputs are a specially formatted tabular representation of predictions._
 Each row corresponds to a unique prediction, and each column provides information about what is being predicted, its scope, and its value. 
 Per hubverse convention, **there are two groups of columns providing metadata about the prediction**[^model-id], followed by **a value column with the actual output**. Each group of columns serves a specific purpose: (1) the **"task ID"** columns provide details about what is being predicted, and (2) the two **"model output representation"** columns specify the type of prediction and identifying information about that prediction. Finally, (3) the **value** column provides the model output of the prediction. [Details about the column specifications](column-details) can be found below.
 
-[^model-id]: When using models for downstream analysis with the [`collect_hub()` function](https://hubverse-org.github.io/hubData/reference/collect_hub.html) in the `hubData` package, one more column called `model_id` is prepended added that identifies the model from its filename. 
+[^model-id]: When using models for downstream analysis with the [`collect_hub()` function](https://hubverse-org.github.io/hubData/reference/collect_hub.html) in the `hubData` package, one more column called `model_id` is prepended that identifies the model from its filename. 
 
 The model output follows the specification of the `tasks.json` configuration
 file of the hub. If you are creating a model and you would like to know what
@@ -227,6 +227,7 @@ In these examples, we are assuming the following variables already exist:
  - `model_out` is the tabular output from your model formatted as specified
    in [the formats of model output section](#formats-of-model-output).
  - `hub_path` is the path to the hub cloned on your local computer
+ - `model_id` is the combination of `<team_abbr>-<model_abbr>` 
  - `file_name` is the file name of your model formatted as
    `<round_id>-<model_id>.csv` (or parquet)
 
@@ -239,11 +240,9 @@ the `to_csv()` method in Python.
 #### Writing CSV with R
 
 ```r
-library("fs")
-library("readr")
 # ... generate model data ...
-outfile <- path(hub_path, "model-output", "team1-modelA", model_id)
-write_csv(model_out, outfile)
+outfile <- fs::path(hub_path, "model-output", model_id, file_name)
+readr::write_csv(model_out, outfile)
 ```
 
 #### Writing CSV with Python
@@ -268,10 +267,8 @@ In practice, you will need to know whether or not the expected data type is a
 #### Writing parquet with R
 
 ```r
-library("fs")
-library("arrow")
 # ... generate model data ...
-outfile <- path(hub_path, "model-output", "team1-modelA", model_id)
+outfile <- fs::path(hub_path, "model-output", model_id, file_name)
 model_out$output_type_id <- as.character(model_out$output_type_id) # or as.numeric(), or as.integer()
 arrow::write_parquet(model_out, outfile)
 ```

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -130,8 +130,9 @@ The model output type IDs have different caveats depending on the `output_type`:
 point estimate for each combination of task IDs. However, because the
 `output_type_id` column is required, something has to go in this place, which
 is a missing value. This is encoded as [`NA` in
-R](https://www.njtierney.com/post/2020/09/17/missing-flavour/) and `None` in Python. See
-[The example on writing parquet files](#example-parquet) for details.
+R](https://www.njtierney.com/post/2020/09/17/missing-flavour/) and `None` in
+Python. See [The example on writing parquet files](#example-parquet) for
+details.
 
 `pmf`
 : Values are required to sum to 1 across all
@@ -159,27 +160,29 @@ variables — further details are discussed below.
 
 The model output follows the specification of the `tasks.json` configuration
 file of the hub. If you are creating a model and would like to know what
-data type your columns should be in, the hubVerse has utilities to provide an
-arrow schema and even a full submission template from the `tasks.json`
-configuration file. 
+data type your columns should be in, the Hubverse has utilities to provide [an
+arrow schema](#arrow-schema) and even a [full submission
+template](#submission-template) from the `tasks.json` configuration file. 
 
 When submitting model output to a hub, it should be placed in a folder with the
 name of your `model_id` in the model outputs folder specified by the hub
-administrator (this is usually called `model-output`). Below are R and Python examples
-for writing Hubverse-compliant model output files in both CSV and parquet format.
-In these examples, we are assuming the following variables already exist:
+administrator (this is usually called `model-output`). Below are R and Python
+examples for writing Hubverse-compliant model output files in both CSV and
+parquet format. In these examples, we are assuming the following variables
+already exist:
 
  - `hub_path` is the path to the hub cloned on your local computer
- - `model_id` is the combination of `<team_abbr>-<model_abbr>` 
+ - `model_id` is the combination of `<team_abbr>-<model_abbr>`
  - `file_name` is the file name of your model formatted as
    `<round_id>-<model_id>.csv` (or `.parquet`)
  - `model_out` is the tabular output from your model formatted as specified
    in [the formats of model output section](#formats-of-model-output).
 
+(submission-template)=
 ### Submission Template
 
 **The hubverse package `hubValidations()` has functionality
-that will generate template data to get your started.** This submission
+that will generate template data to get you started.** This submission
 template can be written as a CSV or parquet file and then imported in to
 whatever software you use to run your model.
 
@@ -213,7 +216,11 @@ arrow::write_parquet(tmpl, "/path/to/template.parquet")
 (example-csv)=
 ### Example: model output as CSV
 
-The sections below provide examples for writing CSV model output files.
+The sections below provide examples for writing CSV model output files. A note
+that missing data in a CSV file should be either a blank cell (that is, two 
+adjacent commas `,,`) or `NA` without quotes[^no-quotes] (e.g. `,NA,`).
+
+[^no-quotes]: You can quote me on this: No quotes.
 
 #### Writing CSV with R
 
@@ -240,16 +247,17 @@ model_out.to_csv(outfile, index = False)
 ### Example: model output as parquet
 
 Unlike a CSV, a parquet files contain embedded information about the data types
-of its columns. 
+of its columns.
 Therefore, when writing model output files as parquet, it's
 critical that you first ensure the data type of your columns matches the
-expected type from the Arrow schema.
+expected type from [the Arrow schema](#arrow-schema).
 
 If the data types of the model output parquet file don't match the hub's schema, the
 submission will not validate.
 In practice, you will need to know whether or not the expected data type is a
 **string/character**, **float/numeric**, or an **Int/integer**.
 
+(arrow-schema)=
 #### Arrow Schema
 
 **The hubverse packages `hubData()` and `hubUtils()` have functionality that will generate an

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -156,7 +156,7 @@ administrator (this is usually called `model-output`). Below are two examples
 of writing model output to a hub in R and Python using parquet and CSV files.
 In these examples, we are assuming the following variables already exist:
 
- - `model_out_tbl` is the tabular output from your model formatted as specified
+ - `model_out` is the tabular output from your model formatted as specified
    in [the formats of model output section](#formats-of-model-output).
  - `hub_path` is the path to the hub cloned on your local computer
  - `file_name` is the file name of your model formatted as
@@ -175,7 +175,7 @@ library("fs")
 library("readr")
 # ... generate model data ...
 outfile <- path(hub_path, "model-output", "team1-modelA", model_id)
-write_csv(model_out_tbl, outfile)
+write_csv(model_out, outfile)
 ```
 
 #### Writing CSV with Python
@@ -185,7 +185,7 @@ import pandas as pd
 import os.path
 # ... generate model data ...
 outfile = os.path.join(hub_path, "model-output", "team1-modelA", model_id)
-model_out_tbl.to_csv(outfile, index = False, na_rep = "NA")
+model_out.to_csv(outfile, index = False, na_rep = "NA")
 ```
 
 (example-parquet)=
@@ -205,8 +205,8 @@ library("fs")
 library("arrow")
 # ... generate model data ...
 outfile <- path(hub_path, "model-output", "team1-modelA", model_id)
-model_out_tbl$output_type_id <- as.character(model_out_tbl$output_type_id) # or as.numeric()
-arrow::write_parquet(model_out_tbl, outfile)
+model_out$output_type_id <- as.character(model_out$output_type_id) # or as.numeric()
+arrow::write_parquet(model_out, outfile)
 ```
 
 
@@ -217,8 +217,8 @@ import pandas as pd
 import os.path
 # ... generate model data ...
 outfile = os.path.join(hub_path, "model-output", "team1-modelA", model_id)
-model_out_tbl["output_type_id"] = model_out_tbl["output_type_id"].astype("string") # or "float"
-model_out_tbl.to_parquet(outfile)
+model_out["output_type_id"] = model_out["output_type_id"].astype("string") # or "float"
+model_out.to_parquet(outfile)
 ```
 
 (model-output-task-relationship)=

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -98,7 +98,7 @@ configuration file.
 
 ### Arrow Schema
 
-**The hubverse package `hubData()` has functionality that will generate an
+**The hubverse packages `hubData()` and `hubUtils()` have functionality that will generate an
 arrow schema so that you can ensure your output matches the expected type.** 
 
 Here is some example code that can help. In this example, `tasks_path` is the

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -92,7 +92,7 @@ Per hubverse convention, **there are two groups of columns providing metadata ab
 
 The model output follows the specification of the `tasks.json` configuration
 file of the hub. If you are creating a model and would like to know what
-data type your columns should be in, the hubVerse has utilities to provide and
+data type your columns should be in, the hubVerse has utilities to provide an
 arrow schema and even a full submission template from the `tasks.json`
 configuration file. 
 
@@ -188,8 +188,7 @@ The model output type IDs have different caveats depending on the `output_type`:
 point estimate for each combination of task IDs. However, because the
 `output_type_id` column is required, something has to go in this place, which
 is a missing value. This is encoded as [`NA` in
-R](https://www.njtierney.com/post/2020/09/17/missing-flavour/) (which is why
-our schemas prior to 4.0.0 encoded these as `["NA"]`) and `None` in Python. See
+R](https://www.njtierney.com/post/2020/09/17/missing-flavour/) and `None` in Python. See
 [The example on writing parquet files](#example-parquet) for details.
 
 `pmf`
@@ -259,9 +258,13 @@ model_out.to_csv(outfile, index = False, na_rep = "NA")
 (example-parquet)=
 ### Example: model output as parquet
 
-Writing to parquet is similar as writing to CSV, but with the caveat that you
-additionally need to ensure that the `output_type_id` column matches the
+Unlike a CSV, a parquet files contain embedded information about the data types of its
+columns. Therefore, when writing model output files as parquet, it's critical that you
+first ensure the data type of the `output_type_id` column matches the
 [expected `output_type_id_datatype` property of the schema](#output-type-id-datatype).
+
+If the data types of the model output parquet file don't match the hub's schema, the
+submission will not validate.
 In practice, you will need to know whether or not the expected data type is a
 **string/character**, **float/numeric**, or an **Int/integer**.
 
@@ -270,6 +273,7 @@ In practice, you will need to know whether or not the expected data type is a
 ```r
 # ... generate model data ...
 outfile <- fs::path(hub_path, "model-output", model_id, file_name)
+# update the output_type_id data type to match the hub's schema
 model_out$output_type_id <- as.character(model_out$output_type_id) # or as.numeric(), or as.integer()
 arrow::write_parquet(model_out, outfile)
 ```
@@ -282,6 +286,7 @@ import pandas as pd
 import os.path
 # ... generate model data ...
 outfile = os.path.join(hub_path, "model-output", "team1-modelA", file_name)
+# update the output_type_id data type to match the hub's schema
 model_out["output_type_id"] = model_out["output_type_id"].astype("string") # or "float", or "Int64"
 model_out.to_parquet(outfile)
 ```

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -181,7 +181,7 @@ already exist:
 (submission-template)=
 ### Submission Template
 
-**The hubverse package `hubValidations()` has functionality
+**The hubverse package `hubValidations` has functionality
 that will generate template data to get you started.** This submission
 template can be written as a CSV or parquet file and then imported in to
 whatever software you use to run your model.
@@ -260,7 +260,7 @@ In practice, you will need to know whether or not the expected data type is a
 (arrow-schema)=
 #### Arrow Schema
 
-**The hubverse packages `hubData()` and `hubUtils()` have functionality that will generate an
+**The hubverse packages `hubData` and `hubUtils` have functionality that will generate an
 arrow schema so that you can ensure your output matches the expected type.** 
 
 Here is some example code that can help. In this example, `hub_path` is the
@@ -287,6 +287,11 @@ value: int32
 model_id: string
 ```
 
+If you have a data frame of model output data (e.g. `model_out`) and want to coerce the column data types to the hub schema, you can also use [`hubData::coerce_to_hub_schema()`](https://hubverse-org.github.io/hubData/reference/coerce_to_hub_schema.html), e.g. 
+```r
+hubData::coerce_to_hub_schema(model_out, config_tasks)
+```
+
 #### Writing parquet with R
 
 ```r
@@ -294,7 +299,7 @@ model_id: string
 outfile <- fs::path(hub_path, "model-output", model_id, file_name)
 
 # update the output_type_id data type to match the hub's schema
-model_out$output_type_id <- as.character(model_out$output_type_id) # or as.numeric(), or as.integer()
+model_out$output_type_id <- as.numeric(model_out$output_type_id) # or as.character(), or as.integer()
 arrow::write_parquet(model_out, outfile)
 ```
 
@@ -308,7 +313,7 @@ import os.path
 outfile = os.path.join(hub_path, "model-output", model_id, file_name)
 
 # update the output_type_id data type to match the hub's schema
-model_out["output_type_id"] = model_out["output_type_id"].astype("string") # or "float", or "Int64"
+model_out["output_type_id"] = model_out["output_type_id"].astype("float") # or "string", or "Int64"
 model_out.to_parquet(outfile)
 ```
 

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -233,7 +233,8 @@ readr::write_csv(model_out, outfile)
 
 #### Writing CSV with Python
 
-Python users can use the `pandas` package when creating CSV model output files.
+This example uses the `pandas` package when creating CSV model output files.
+
 ```python
 import pandas as pd
 import os.path
@@ -287,24 +288,32 @@ value: int32
 model_id: string
 ```
 
-If you have a data frame of model output data (e.g. `model_out`) and want to coerce the column data types to the hub schema, you can also use [`hubData::coerce_to_hub_schema()`](https://hubverse-org.github.io/hubData/reference/coerce_to_hub_schema.html), e.g. 
-```r
-hubData::coerce_to_hub_schema(model_out, config_tasks)
-```
 
 #### Writing parquet with R
+
+You can use the
+[`hubData::coerce_to_hub_schema()`](https://hubverse-org.github.io/hubData/reference/coerce_to_hub_schema.html), function to ensure your data is in the correct format before writing out.
 
 ```r
 # ... generate model data ...
 outfile <- fs::path(hub_path, "model-output", model_id, file_name)
 
-# update the output_type_id data type to match the hub's schema
-model_out$output_type_id <- as.numeric(model_out$output_type_id) # or as.character(), or as.integer()
+# coerce model output data to the data types of the hub schema
+config_tasks <- hubData::read_config(hub_path, "tasks")
+model_out <- hubData::coerce_to_hub_schema(model_out, config_tasks)
+
+# write to parquet file
 arrow::write_parquet(model_out, outfile)
 ```
 
 
 #### Writing parquet with Python
+
+his example uses the `pandas` package to create parquet files. Importantly, if
+you are creating a parquet file, you will need to **ensure your column types
+match the hub schema**. You can do this by using the [`astype()` method](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.astype.html) for pandas DataFrames[^polars]
+
+[^polars]: If you prefer to use polars for your model output, you would use the polars [`cast()` method](https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.cast.html#polars.DataFrame.cast).
 
 ```python
 import pandas as pd

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -50,7 +50,7 @@ one-week-ahead incidence, but probabilities for the timing of a season peak:
   This is discussed in the [Output type table](#output-type-table)
 
 
-(formats-of-model-output)=
+(file-formats)=
 ### File formats
 
 Hubs can take submissions in tabular data formats, namely `csv` and `parquet`. These
@@ -70,7 +70,10 @@ submission formats are _not mutually exclusive_; **hubs may choose between
    * Disadvantages:
       * Compatibility: Harder to work with; teams and people who want to work with files need to install additional libraries
 
-(model-output-format)=
+Examples of how to create these file formats in R and Python are listed below in
+[the Writing Model Output section](#writing-model-output).
+
+(formats-of-model-output)=
 ## Formats of model output
 
 ```{admonition} Reference
@@ -157,21 +160,28 @@ variables — further details are discussed below.
 
 :::
 
+(writing-model-output)=
 ## Writing model output to a hub
 
 When submitting model output to a hub, it should be placed in a folder with the
-name of your model in the model outputs folder specified by the hub administrator
-(this is usually called `model-output`). Below are two examples of writing model
-output to a hub in R and Python using parquet and CSV files. In these examples,
-we are assuming that `path_to_hub` is the path to the hub cloned on your local
-computer and `model_out_tbl` is the
-tabular output from your model formatted as specified above.
+name of your model in the model outputs folder specified by the hub
+administrator (this is usually called `model-output`). Below are two examples
+of writing model output to a hub in R and Python using parquet and CSV files.
+In these examples, we are assuming the following variables already exist:
+
+ - `model_out_tbl` is the tabular output from your model formatted as specified
+   in [the Formats of Model Output section](#formats-of-model-output).
+ - `path_to_hub` is the path to the hub cloned on your local computer
+ - `model_name` is the file name of your model formatted as
+   `<round_id>-<model_name>.csv` (or parquet)
 
 (example-csv)=
 ### Example: model output as CSV
 
 To write to CSV, you would use the `write_csv()` from the readr package in R and
 the `to_csv()` method in Python. 
+
+#### Writing CSV with R
 
 ```r
 library("fs")
@@ -180,6 +190,8 @@ library("readr")
 outfile <- path(path_to_hub, "model-output", "team1-modelA", model_name)
 write_csv(model_out_tbl, outfile)
 ```
+
+#### Writing CSV with Python
 
 ```python
 import pandas as pd
@@ -198,6 +210,9 @@ additionally need to ensure that the `output_type_id` column matches the
 In practice, you will need to know whether or not the expected data type is a
 **string/character** or a **float/numeric**.
 
+
+#### Writing parquet with R
+
 ```r
 library("fs")
 library("arrow")
@@ -206,6 +221,9 @@ outfile <- path(path_to_hub, "model-output", "team1-modelA", model_name)
 model_out_tbl$output_type_id <- as.character(model_out_tbl$output_type_id) # or as.numeric()
 arrow::write_parquet(model_out_tbl, outfile)
 ```
+
+
+#### Writing parquet with Python
 
 ```python
 import pandas as pd

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -298,14 +298,14 @@ We emphasize that the `mean`, `median`, `quantile`, `cdf`, and `pmf` representat
 In contrast, we cannot assume the same for the `sample` representation.
 By recording samples from a joint predictive distribution, **the `sample` representation may capture dependence across combinations of multiple model task ID variables**.
 
-For example, suppose the model task ID variables are “forecast date”, “location”, and “horizon”. 
+For example, suppose the model task ID variables are "forecast date", "location", and "horizon". 
 A predictive mean will summarize the predictive distribution for a single combination of forecast date, location, and horizon. On the other hand, there are several options for the distribution from which a sample might be drawn, capturing dependence across different levels of the task ID variables, including:
 1. the joint predictive distribution across all locations and horizons within each forecast date
 2. the joint predictive distribution across all horizons within each forecast date and location
 3. the joint predictive distribution across all locations within each forecast date and horizon
 4. the marginal predictive distribution for each combination of forecast date, location, and horizon
 
-Hubs should specify the collection of task ID variables for which samples are expected to capture dependence; e.g., the first option listed above might specify that samples should be drawn from distributions that are “joint across” locations and horizons.  
+Hubs should specify the collection of task ID variables for which samples are expected to capture dependence; e.g., the first option listed above might specify that samples should be drawn from distributions that are "joint across" locations and horizons.  
 
 More details about sample-output-type can be found in the [page describing sample output type data](../user-guide/sample-output-type.md).
 
@@ -320,7 +320,7 @@ Some other possible model output representations have been proposed but not incl
    * We considered a system with a more flexible specification of bin endpoint inclusion status but noted two disadvantages:
       * This additional flexibility would introduce substantial extra complexity to the metadata specifications and tooling
       * Adopting limited standards that encourage hubs to adopt settings consistent with the common definitions might be beneficial. For example, if a hub adopted bins with open right endpoints, the resulting probabilities would be incompatible with the conventions around cumulative distribution functions.
-* Probability of “success” in a setting with a binary outcome
+* Probability of "success" in a setting with a binary outcome
    * This can be captured with a CDF representation if the outcome variable is ordered or a categorical representation if the outcome variable is not.
 * Compositional. For example, we might request a probabilistic estimate of the proportion of hospitalizations next week due to influenza A/H1, A/H3, and B.
    * Note that a categorical output representation could be used if only point estimates for the composition were required.

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -251,8 +251,8 @@ Python users can use the `pandas` package when creating CSV model output files.
 import pandas as pd
 import os.path
 # ... generate model data ...
-outfile = os.path.join(hub_path, "model-output", "team1-modelA", file_name)
-model_out.to_csv(outfile, index = False, na_rep = "NA")
+outfile = os.path.join(hub_path, "model-output", model_id, file_name)
+model_out.to_csv(outfile, index = False)
 ```
 
 (example-parquet)=
@@ -285,7 +285,7 @@ arrow::write_parquet(model_out, outfile)
 import pandas as pd
 import os.path
 # ... generate model data ...
-outfile = os.path.join(hub_path, "model-output", "team1-modelA", file_name)
+outfile = os.path.join(hub_path, "model-output", model_id, file_name)
 # update the output_type_id data type to match the hub's schema
 model_out["output_type_id"] = model_out["output_type_id"].astype("string") # or "float", or "Int64"
 model_out.to_parquet(outfile)

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -158,9 +158,9 @@ In these examples, we are assuming the following variables already exist:
 
  - `model_out_tbl` is the tabular output from your model formatted as specified
    in [the formats of model output section](#formats-of-model-output).
- - `path_to_hub` is the path to the hub cloned on your local computer
- - `model_name` is the file name of your model formatted as
-   `<round_id>-<model_name>.csv` (or parquet)
+ - `hub_path` is the path to the hub cloned on your local computer
+ - `file_name` is the file name of your model formatted as
+   `<round_id>-<model_id>.csv` (or parquet)
 
 (example-csv)=
 ### Example: model output as CSV
@@ -174,7 +174,7 @@ the `to_csv()` method in Python.
 library("fs")
 library("readr")
 # ... generate model data ...
-outfile <- path(path_to_hub, "model-output", "team1-modelA", model_name)
+outfile <- path(hub_path, "model-output", "team1-modelA", model_id)
 write_csv(model_out_tbl, outfile)
 ```
 
@@ -184,7 +184,7 @@ write_csv(model_out_tbl, outfile)
 import pandas as pd
 import os.path
 # ... generate model data ...
-outfile = os.path.join(path_to_hub, "model-output", "team1-modelA", model_name)
+outfile = os.path.join(hub_path, "model-output", "team1-modelA", model_id)
 model_out_tbl.to_csv(outfile, index = False, na_rep = "NA")
 ```
 
@@ -204,7 +204,7 @@ In practice, you will need to know whether or not the expected data type is a
 library("fs")
 library("arrow")
 # ... generate model data ...
-outfile <- path(path_to_hub, "model-output", "team1-modelA", model_name)
+outfile <- path(hub_path, "model-output", "team1-modelA", model_id)
 model_out_tbl$output_type_id <- as.character(model_out_tbl$output_type_id) # or as.numeric()
 arrow::write_parquet(model_out_tbl, outfile)
 ```
@@ -216,7 +216,7 @@ arrow::write_parquet(model_out_tbl, outfile)
 import pandas as pd
 import os.path
 # ... generate model data ...
-outfile = os.path.join(path_to_hub, "model-output", "team1-modelA", model_name)
+outfile = os.path.join(hub_path, "model-output", "team1-modelA", model_id)
 model_out_tbl["output_type_id"] = model_out_tbl["output_type_id"].astype("string") # or "float"
 model_out_tbl.to_parquet(outfile)
 ```


### PR DESCRIPTION
This modifies the description of `output_type_id` for point estimates to clearly state that the entry should be a missing value, either `NA` in R or `None` in Python. 

This also states that this applies to schemas prior to v4.0.0 (see https://github.com/hubverse-org/schemas/issues/109) and adds the python one-liner as suggested by @MKupperman in https://github.com/hubverse-org/hubDocs/issues/198.


The preview for this PR is at https://hubdocs--197.org.readthedocs.build/en/197/user-guide/model-output.html
