### PR TITLE
redefine model output representation to be two columns 

### DIFF
--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -78,7 +78,7 @@ Much of the material in this section has been excerpted or adapted from the [hub
 
 _Model outputs are a specially formatted tabular representation of predictions._
 Each row corresponds to a unique prediction, and each column provides information about what is being predicted, its scope, and its value. 
-Per hubverse convention, **there are two groups of columns and one column for model output**[^model-id]. Each group of columns serves a specific purpose: (1) the **"task ID"** columns provide details about what is being predicted, and (2) the two **"model output representation"** columns specify the type of prediction and identifying information about that prediction. Finally, (3) the **value** column provides the model output of the prediction.  
+Per hubverse convention, **there are two groups of columns providing metadata about the prediction**[^model-id], followed by **a value column with the actual output**. Each group of columns serves a specific purpose: (1) the **"task ID"** columns provide details about what is being predicted, and (2) the two **"model output representation"** columns specify the type of prediction and identifying information about that prediction. Finally, (3) the **value** column provides the model output of the prediction.  
 
 [^model-id]: When using models for downstream analysis with the [`collect_hub()` function](https://hubverse-org.github.io/hubData/reference/collect_hub.html) in the `hubData` package, one more column called `model_id` is prepended added that identifies the model from its filename. 
 

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -82,7 +82,7 @@ Per hubverse convention, **there are two groups of columns**[^model-id], each gr
 
 [^model-id]: When using models for downstream analysis with the [`collect_hub()` function](https://hubverse-org.github.io/hubData/reference/collect_hub.html) in the `hubData` package, one more column called `model_id` is prepended added that identifies the model from its filename. 
 
-As shown in the [model output submission table](#model-output-example-table) above, there are three **"task ID"** columns: `origin_epiweek`, `target`, and `horizon`; and there are three **"model output representation"** columns: `output_type`, `output_type_id`, and `value`.  
+As shown in the [model output submission table](#model-output-example-table) above, there are three **"task ID"** columns: `origin_epiweek`, `target`, and `horizon`; and there are two **"model output representation"** columns: `output_type` and `output_type_id` followed by the `value` column.  
 More detail about each of these column groups is given in the following points:  
 
 1. **"Task IDs" (multiple columns)**:  The details of the outcome (the model task) are provided by the modeler and can be stored in a series of "task ID" columns as described in this [section on task ID variables](#task-id-vars). These "task ID" columns may also include additional information, such as any conditions or assumptions that were used to generate the predictions. Some example task ID variables include `target`, `location`, `reference_date`, and `horizon`. Although there are no restrictions on naming task ID variables, we suggest that hubs adopt the standard task ID or column names and definitions specified in the [section on usage of task ID variables](#task-id-use) when appropriate.  

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -78,7 +78,7 @@ Much of the material in this section has been excerpted or adapted from the [hub
 
 _Model outputs are a specially formatted tabular representation of predictions._
 Each row corresponds to a unique prediction, and each column provides information about what is being predicted, its scope, and its value. 
-Per hubverse convention, **there are two groups of columns**[^model-id], each group serving a specific purpose: (1) the **"task ID"** columns provide details about what is being predicted, and (2) the three **"model output representation"** columns specifies the type of prediction, identifying information about that prediction, and the value of the prediction. 
+Per hubverse convention, **there are two groups of columns and one column for model output**[^model-id]. Each group of columns serves a specific purpose: (1) the **"task ID"** columns provide details about what is being predicted, and (2) the two **"model output representation"** columns specify the type of prediction, and identifying information about that prediction. Finally, (3) the **value** column provides the model output of the prediction.  
 
 [^model-id]: When using models for downstream analysis with the [`collect_hub()` function](https://hubverse-org.github.io/hubData/reference/collect_hub.html) in the `hubData` package, one more column called `model_id` is prepended added that identifies the model from its filename. 
 

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -87,8 +87,8 @@ More detail about each of these column groups is given in the following points:
 
 1. **"Task IDs" (multiple columns)**:  The details of the outcome (the model task) are provided by the modeler and can be stored in a series of "task ID" columns as described in this [section on task ID variables](#task-id-vars). These "task ID" columns may also include additional information, such as any conditions or assumptions that were used to generate the predictions. Some example task ID variables include `target`, `location`, `reference_date`, and `horizon`. Although there are no restrictions on naming task ID variables, we suggest that hubs adopt the standard task ID or column names and definitions specified in the [section on usage of task ID variables](#task-id-use) when appropriate.  
 2. **"Model output representation" (2 columns)**: consists of two columns specifying how the model outputs are represented. Both of these columns will be present in all model output data:  
-  - (i) `output_type` specifies the type of representation of the predictive distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`, `"pmf"`, or `"sample"`.  
-  - (ii) `output_type_id` specifies more identifying information specific to the output type, which varies depending on the `output_type`.  
+    - (i) `output_type` specifies the type of representation of the predictive distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`, `"pmf"`, or `"sample"`.  
+    - (ii) `output_type_id` specifies more identifying information specific to the output type, which varies depending on the `output_type`.  
 3. `value` contains the model’s prediction.  
 
 The following table provides more detail on how to configure the three "model output representation" columns based on each model output type:

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -87,8 +87,8 @@ More detail about each of these column groups is given in the following points:
 
 1. **"Task IDs" (multiple columns)**:  The details of the outcome (the model task) are provided by the modeler and can be stored in a series of "task ID" columns as described in this [section on task ID variables](#task-id-vars). These "task ID" columns may also include additional information, such as any conditions or assumptions that were used to generate the predictions. Some example task ID variables include `target`, `location`, `reference_date`, and `horizon`. Although there are no restrictions on naming task ID variables, we suggest that hubs adopt the standard task ID or column names and definitions specified in the [section on usage of task ID variables](#task-id-use) when appropriate.  
 2. **"Model output representation" (2 columns)**: consists of two columns specifying how the model outputs are represented. Both of these columns will be present in all model output data:  
-    - (i) `output_type` specifies the type of representation of the predictive distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`, `"pmf"`, or `"sample"`.  
-    - (ii) `output_type_id` specifies more identifying information specific to the output type, which varies depending on the `output_type`.  
+    1. `output_type` specifies the type of representation of the predictive distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`, `"pmf"`, or `"sample"`.  
+    2. `output_type_id` specifies more identifying information specific to the output type, which varies depending on the `output_type`.  
 3. `value` contains the model’s prediction.  
 
 The following table provides more detail on how to configure the three "model output representation" columns based on each model output type:

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -85,7 +85,7 @@ Per hubverse convention, **there are two groups of columns and one column for mo
 As shown in the [model output submission table](#model-output-example-table) above, there are three **"task ID"** columns: `origin_epiweek`, `target`, and `horizon`; and there are two **"model output representation"** columns: `output_type` and `output_type_id` followed by the `value` column.  
 More detail about each of these column groups is given in the following points:  
 
-1. **"Task IDs" (multiple columns)**:  The details of the outcome (the model task) are provided by the modeler and can be stored in a series of "task ID" columns as described in this [section on task ID variables](#task-id-vars). These "task ID" columns may also include additional information, such as any conditions or assumptions that were used to generate the predictions. Some example task ID variables include `target`, `location`, `reference_date`, and `horizon`. Although there are no restrictions on naming task ID variables, we suggest that hubs adopt the standard task ID or column names and definitions specified in the [section on usage of task ID variables](#task-id-use) when appropriate.  
+1. **"Task IDs" (multiple columns)**:  The details of the outcome (the model task) are provided by the modeler and can be stored in a series of "task ID" columns as described in this [section on task ID variables](#task-id-vars). These "task ID" columns may also include additional information, such as any conditions or assumptions used to generate the predictions. Some example task ID variables include `target`, `location`, `reference_date`, and `horizon`. Although there are no restrictions on naming task ID variables, we suggest that hubs adopt the standard task ID or column names and definitions specified in the [section on usage of task ID variables](#task-id-use) when appropriate.  
 2. **"Model output representation" (2 columns)**: consists of two columns specifying how the model outputs are represented. Both of these columns will be present in all model output data:  
     1. `output_type` specifies the type of representation of the predictive distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`, `"pmf"`, or `"sample"`.  
     2. `output_type_id` specifies more identifying information specific to the output type, which varies depending on the `output_type`.  
@@ -147,7 +147,7 @@ Some other possible model output representations have been proposed but not incl
       * This additional flexibility would introduce substantial extra complexity to the metadata specifications and tooling
       * Adopting limited standards that encourage hubs to adopt settings consistent with the common definitions might be beneficial. For example, if a hub adopted bins with open right endpoints, the resulting probabilities would be incompatible with the conventions around cumulative distribution functions.
 * Probability of “success” in a setting with a binary outcome
-   * This can be captured with a CDF representation if the outcome variable is ordered or a categorical representation if the outcome variable is not ordered.
+   * This can be captured with a CDF representation if the outcome variable is ordered or a categorical representation if the outcome variable is not.
 * Compositional. For example, we might request a probabilistic estimate of the proportion of hospitalizations next week due to influenza A/H1, A/H3, and B.
    * Note that a categorical output representation could be used if only point estimates for the composition were required.
 
@@ -203,7 +203,7 @@ Changing the overall data type of model output columns can cause a range of issu
 
 Output types are configured and handled differently than task IDs in the hubverse. 
 
-On the one hand, **different output types can have output type ID values of varying data type**, and adhering to these data types is imposed by downstream, output type specific hubverse functionality like ensembling or visualization.
+On the one hand, **different output types can have output type ID values of varying data type**, and adhering to these data types is imposed by downstream, output type-specific hubverse functionality like ensembling or visualization.
 For example, hubs expect `double` output type ID values for `quantile` output types but `character` output type IDs for a `pmf` output type. 
 
  On the other hand, the **use of a long format for hubverse model output files requires that these multiple data types are accommodated in a single `output_type_id` column.**

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -82,29 +82,14 @@ Per hubverse convention, **there are two groups of columns**[^model-id], each gr
 
 [^model-id]: When using models for downstream analysis with the [`collect_hub()` function](https://hubverse-org.github.io/hubData/reference/collect_hub.html) in the `hubData` package, one more column called `model_id` is prepended added that identifies the model from its filename. 
 
-As shown in the [model output submission table](#model-output-example-table) above, there are three **"task ID"** columns: `origin_epiweek`, `target`, and `horizon`; and there are three **"model output representation"** columns: `output_type`, `output_type_id`, and `value`.
+As shown in the [model output submission table](#model-output-example-table) above, there are three **"task ID"** columns: `origin_epiweek`, `target`, and `horizon`; and there are three **"model output representation"** columns: `output_type`, `output_type_id`, and `value`.  
 More detail about each of these column groups is given in the following points:  
 
-1. **"Task IDs" (multiple columns)**:  The details of the outcome (the model
-   task) are provided by the modeler and can be stored in a series of "task
-   ID" columns as described in this [section on task ID
-   variables](#task-id-vars). These "task ID" columns may also include
-   additional information, such as any conditions or assumptions that were used
-   to generate the predictions. Some example task ID variables include
-   `target`, `location`, `reference_date`, and `horizon`.    Although there are
-   no restrictions on naming task ID variables, we suggest
-that hubs adopt the standard task ID or column names and definitions
-specified in the [section on usage of task ID variables](#task-id-use) when appropriate.
-2. **"Model output representation" (3 columns)**: consists of three
-   columns specifying how the model outputs are represented. All three of these
-   columns will be present in all model output data:
-  1. `output_type` specifies the type of representation of the predictive
-     distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`,
-     `"pmf"`, or `"sample"`.
-  2. `output_type_id` specifies more identifying information specific to the
-     output type, which varies depending on the `output_type`.
-  3. `value` contains the model’s prediction.
-
+1. **"Task IDs" (multiple columns)**:  The details of the outcome (the model task) are provided by the modeler and can be stored in a series of "task ID" columns as described in this [section on task ID variables](#task-id-vars). These "task ID" columns may also include additional information, such as any conditions or assumptions that were used to generate the predictions. Some example task ID variables include `target`, `location`, `reference_date`, and `horizon`. Although there are no restrictions on naming task ID variables, we suggest that hubs adopt the standard task ID or column names and definitions specified in the [section on usage of task ID variables](#task-id-use) when appropriate.  
+2. **"Model output representation" (2 columns)**: consists of two columns specifying how the model outputs are represented. Both of these columns will be present in all model output data:  
+  - (i) `output_type` specifies the type of representation of the predictive distribution, namely `"mean"`, `"median"`, `"quantile"`, `"cdf"`, `"cmf"`, `"pmf"`, or `"sample"`.  
+  - (ii) `output_type_id` specifies more identifying information specific to the output type, which varies depending on the `output_type`.  
+3. `value` contains the model’s prediction.  
 
 The following table provides more detail on how to configure the three "model output representation" columns based on each model output type:
 

--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -78,7 +78,7 @@ Much of the material in this section has been excerpted or adapted from the [hub
 
 _Model outputs are a specially formatted tabular representation of predictions._
 Each row corresponds to a unique prediction, and each column provides information about what is being predicted, its scope, and its value. 
-Per hubverse convention, **there are two groups of columns and one column for model output**[^model-id]. Each group of columns serves a specific purpose: (1) the **"task ID"** columns provide details about what is being predicted, and (2) the two **"model output representation"** columns specify the type of prediction, and identifying information about that prediction. Finally, (3) the **value** column provides the model output of the prediction.  
+Per hubverse convention, **there are two groups of columns and one column for model output**[^model-id]. Each group of columns serves a specific purpose: (1) the **"task ID"** columns provide details about what is being predicted, and (2) the two **"model output representation"** columns specify the type of prediction and identifying information about that prediction. Finally, (3) the **value** column provides the model output of the prediction.  
 
 [^model-id]: When using models for downstream analysis with the [`collect_hub()` function](https://hubverse-org.github.io/hubData/reference/collect_hub.html) in the `hubData` package, one more column called `model_id` is prepended added that identifies the model from its filename. 
 


### PR DESCRIPTION
Addressing issue #201 