### PR TITLE
collapse navbar elements

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,6 +61,7 @@ html_logo = 'images/LOGO-hubverse-withtext.png'
 html_favicon = 'images/hubverse-favicon.png'
 html_title = 'Hubverse'
 html_theme_options = {
+    "show_navbar_depth": 0,
     "home_page_in_toc": False,
     #"github_url": "https://github.com/hubverse-org/hubDocs",
     "repository_url": "https://github.com/hubverse-org/hubDocs",


### PR DESCRIPTION
This [collapses the navbar elements](https://sphinx-book-theme.readthedocs.io/en/stable/sections/sidebar-primary.html#control-the-depth-of-the-left-sidebar-lists-to-expand) according to the book theme docs.

It does what it says on the tin: it collapses the navbar elements, but the downside is now in order to get anywhere, you need to click twice to open the navbar and then go to the link you wanted to go to. 


