### PR TITLE
Only show a single target_keys key value pair to conform to v4.0.1 schema

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,7 +82,7 @@ html_js_files = [
 # -- Options for EPUB output
 epub_show_urls = 'footnote'
 
-schema_version = "v4.0.0"
+schema_version = "v5.0.0"
 # Use schema_branch variable to specify a branch in the schemas repository from which config schema will be source, especially for docson widgets.
 # Useful if the schema being documented hasn't been released to the `main` branch in the schemas repo yet. If version has been released already, set this to "main".
 schema_branch = "br-"+schema_version

--- a/docs/source/quickstart-hub-admin/tasks-config.md
+++ b/docs/source/quickstart-hub-admin/tasks-config.md
@@ -249,7 +249,7 @@ Each output type contains the following properties:
 - To begin with, `"target_id"`{.codeitem} is a short description that uniquely identifies the target.  
 - Similarly, `"target_name"`{.codeitem} provides a longer, human readable description of the target.  
 - `"target_units"`{.codeitem} indicates the unit of observation used for this target.  In this instance, the unit is `"count"`.  
-- `"target_keys"`{.codeitem} expect an object containing key/value pairs that appropriately identify the target. The keys must match the name of a task ID and the values must match a valid task ID value of the task ID.  In this instance, the target is identified by a single task ID (`"target"`), the key is the task ID name `"target"` and the value is `"inc covid hosp"`.  
+- `"target_keys"`{.codeitem} expect an object containing a single key/value pair that appropriately identifies the target. The key must match the name of a task ID and the value must match a valid task ID value of the task ID.  In this instance, the target is identified by task ID (`"target"`), the key is the task ID name `"target"` and the value is `"inc covid hosp"`.  
 - The `"description"`{.codeitem} is a verbose explanation of the target, which might include details on the measure used for the target, as shown in the example below.  
 - The `"target_type"`{.codeitem} defines the target's statistical data type. In this instance, the target uses discrete data.  
 - `"is_step_ahead"`{.codeitem} indicates whether the target is part of a sequence of values.  In this instance, it is.  

--- a/docs/source/user-guide/intro-data-formats.md
+++ b/docs/source/user-guide/intro-data-formats.md
@@ -59,19 +59,6 @@ This hub collects forecasts at 1 through 4 weeks ahead of cases, hospitalization
 The US COVID-19 Forecast Hub did not specify what type of point forecast should be submitted, but here we are being more specific to illustrate what we think would be a best practice.
 ```
 
-(running-example-3)=
-```{admonition} Example 3: Multiple target keys
-Projections are requested for each combination of the following variables.
-
-#### Task ID variables
-
-* `outcome_variable`{.codeitem} (**target key** variable): “hospitalizations”, “cases”, “deaths”
-* `outcome_measure`{.codeitem} (**target key** variable): “incident count”, “cumulative count”
-* `scenario_id`{.codeitem}: “low vaccination”
-* `location`{.codeitem}: “US”
-* `origin_date`{.codeitem}: 2021-07-11
-* `horizon`{.codeitem}: 1
-```
 
 (submission-rounds)=
 ## Submission rounds

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -173,9 +173,6 @@ We therefore strongly suggest that Hubs adopt the following standard task ID or 
 * `location`{.codeitem}: a unique identifier for a location
 * `target`{.codeitem}: a unique identifier for the target.
   It is recommended, although not required, that hubs set up a single variable to define the target (i.e., as a target key), with additional detail specified in the [`target_metadata` array](#target-metadata).
-* `target_variable`{.codeitem}/`target_outcome`: task IDs making up unique identifiers of a two-part target.
-  These tasks can be used in hubs that want to divide the definition of a target across two variables.
-  Both task IDs will be specified as target keys in the [`target_metadata` array](#tasks-metadata).
 * `target_date`{.codeitem}/`target_end_date`: for short-term forecasts, one of the synonymous task IDs `target_date`/`target_end_date` specifies the date of occurrence of the outcome of interest.
   For instance, if models are requested to forecast the number of hospitalizations on 2022-07-15, the `target_date` is 2022-07-15.
 * `horizon`{.codeitem}: The difference between the `target_date` and the `origin_date` in time units specified by the hub (e.g., days, weeks, or months)


### PR DESCRIPTION
This PR resolves #226 

When we began thinking about target metadata, we allowed for target keys to be able to span multiple columns. We have now decided that this represents unnecessary complexity that is not being used. This is now reflected in (under development) schema version v5.0.0 https://github.com/hubverse-org/schemas/pull/118 

The hubDocs documentation should now also reflect this.

This PR is related to https://github.com/hubverse-org/schemas/pull/119 and:

- [Makes explicit that target keys should be a single key value pair in quck start section](https://github.com/hubverse-org/hubDocs/commit/3548ae0b2220277967ae0fe3caaf31d4bf256079)
- [Removes multiple target key hub example](https://github.com/hubverse-org/hubDocs/commit/d4f530fab514d75091dc2ec3c3ab454b49655cdc)
- [Removes mention of multipart target std task IDs](https://github.com/hubverse-org/hubDocs/commit/02745c5e8f50c14ead6b3d41cbc80aabaed35700)