### PR TITLE
Add Python release process

### DIFF
--- a/docs/source/developer/hotfix.md
+++ b/docs/source/developer/hotfix.md
@@ -1,0 +1,260 @@
+# Releasing Hotfixes
+
+This document is adapted for The Hubverse from
+[The Carpentries Developer’s Handbook](https://carpentries.github.io/workbench-dev/hotfixes.html)
+(c) The Carpentries under the [CC-BY 4.0 license](https://creativecommons.org/licenses/by/4.0/).
+
+## Introduction
+
+A hotfix is a bug fix for a situation where a bug has been found, but the main
+branch has new features that are not yet ready to be released.
+
+A process for creating a hotfix release is similar to that of the standard
+release with the following differences:
+
+|        | standard | hotfix |
+| ------ | -------- | ------ |
+| parent branch | `main` | `<tag>` |
+| tag and release | after merge | _before_ merge |
+| merge conflicts | never | with `DESCRIPTION` and `NEWS.md` |
+
+An example of a good candidate for a hotfix in the hubverse is
+[hubValidations issue #123](https://github.com/hubverse-org/hubValidations/issues/123).
+This bug was discovered in [hubValidations 0.6.2](https://github.com/hubverse-org/hubValidations/releases/tag/v0.6.2).
+However, the discovery occurred after the `main` branch already
+[had unreleased features](https://github.com/hubverse-org/hubValidations/commit/85d58251c7cbcbb4064a72f8126ad8846f351dbd).
+While the new features were stable, the documentation was not fully polished[^unreleased].
+A hotfix would give developers more time to document the new feature.
+
+[^unreleased]: [the `create_custom_check()`
+  function](https://github.com/hubverse-org/hubValidations/issues/121) was
+  added in [pull request 122](https://github.com/hubverse-org/hubValidations/pull/122),
+  but the vignette for creating the custom check functions was still in a draft
+  state.
+
+While this bug fix was released through the [standard release process](release-process.md),
+It could have easily been a hotfix release. This document will be a walkthrough
+of the hotfix process if it had been applied in
+[hubValidations pull request 124](https://github.com/hubverse-org/hubValidations/pull/124).
+
+## Conventions
+
+This walkthrough will be presented as if our lead developer, Anna Krystalli
+were fixing the bug (which she did in real life!) via this hotfix process. We
+will diagram the process using the following conventions:
+
+- Each step will be written in the second person perspective
+- The commit IDs and branch names are simplified and will not directly match
+  the real life names
+- Each new commit is a unique sequence of letters
+- Each merge commit is a combination of letters from the two previous commits
+- Each non-main branch will be prefixed with `ak/`
+- The command prompt will be displayed in the following format
+
+   ```sh
+   $ (<branch>) <COMMAND> # comment about <COMMAND>
+   #| output of <COMMAND>
+   ```
+
+## The Scenario
+
+- [hubValidations 0.6.2](https://github.com/hubverse-org/hubValidations/releases/tag/v0.6.2)
+  was released on 2024-09-20.
+- [the `create_custom_check()` function](https://github.com/hubverse-org/hubValidations/pull/122)
+  was merged into hubValidations 0.6.2.9000 on 2024-10-01
+  after it had been tested and validated.
+- the vignette for creating custom validations was being drafted in a separate
+  branch on 2024-10-01.
+- [A bug was discovered in hubValidations 0.6.2 on 2024-10-02](https://github.com/hubverse-org/hubValidations/issues/123).
+
+This is what the state of the project would look like on 2024-10-02 (simplified):
+
+```{mermaid}
+gitGraph
+    commit id: "abcd"
+    commit id: "efgh" tag: "v0.6.2"
+    branch ak/create-fun/121
+    branch ak/document-fun/121
+    checkout main
+    checkout ak/create-fun/121
+    commit id: "ijkl"
+    commit id: "mnop"
+    checkout main
+    merge ak/create-fun/121 id: "gpne"
+    checkout ak/document-fun/121
+    commit id: "qrst"
+    commit id: "uvwx"
+```
+
+The rest of the walkthrough will detail the four steps required to fix the bug.
+
+## Step 1: Create a Fix and Pull Request
+
+Normally, to fix bugs, you would check out a new bugfix branch from the `main`
+branch. Here's the catch: if you check out from the main branch you will grab
+`ak/create-fun/121` as well, which is not yet ready for production because you
+intended `ak/document-fun/121` to be released along side. In this case, you
+need to create a hotfix, and create the branch _from the last tag_ (which in
+this case is `v0.6.2`).
+
+**IMPORTANT**: When you create a hotfix, name the branch
+`<author>/hotfix/<issue>`. By using `/hotfix/` in the branch name, the GitHub
+workflows will know to test this package against the released versions from the
+R-universe.
+
+Python package workflows do not currently have behavior triggered by `/hotfix/`
+in the branch name but should follow this naming convention regardless.
+
+```sh
+(main)$ git describe
+#| v0.6.2-3-ggpne
+(main)$ git switch --detach v0.6.2 # checkout the tag
+#| HEAD is now at efgh Merge pull request #119 from hubverse-org/ak/release/v0.6.2
+((v0.6.2))$ git switch -c ak/hotfix/123 # create a new branch
+#| switched to new branch 'ak/hotfix/123'
+(ak/hotfix/123)$ git push -u origin ak/hotfix/123 # push the branch to GitHub
+```
+
+Now you are ready to iterate and fix the bug on the hotfix branch, adding the
+test and then adding the fix and any documentation to go with it.
+
+```{mermaid}
+gitGraph
+    commit id: "abcd"
+    commit id: "efgh" tag: "v0.6.2"
+    branch ak/create-fun/121
+    branch ak/document-fun/121
+    branch ak/hotfix/123
+    checkout main
+    checkout ak/create-fun/121
+    commit id: "ijkl"
+    commit id: "mnop"
+    checkout main
+    merge ak/create-fun/121 id: "gpne"
+    checkout ak/document-fun/121
+    commit id: "qrst"
+    commit id: "uvwx"
+    checkout ak/hotfix/123
+    commit id: "yzAB"
+```
+
+When you have finished iterating on your own and are satisfied that it works,
+the next step is to open a pull request and get a review.
+
+## Step 2: Ensure checks pass, get a review, and create tag
+
+You should check that the hotfix does not break any existing tests, which are
+automatically run from the pull request. Once you have confirmed that
+everything works as expected and have an approving review, the next step is to
+bump the version and add a tag. This tag will allow you to release the patch
+version.
+
+```sh
+(ak/hotfix/123)$ git add DESCRIPTION NEWS.md
+(ak/hotfix/123)$ git commit -m 'bump version to v0.6.3'
+(ak/hotfix/123)$ git tag -s v0.6.3 -m 'hotfix: validate tasks with optional output types'
+(ak/hotfix/123)$ git push
+(ak/hotfix/123)$ git push --tags
+```
+
+```{mermaid}
+gitGraph
+    commit id: "abcd"
+    commit id: "efgh" tag: "v0.6.2"
+    branch ak/create-fun/121
+    branch ak/document-fun/121
+    branch ak/hotfix/123
+    checkout main
+    checkout ak/create-fun/121
+    commit id: "ijkl"
+    commit id: "mnop"
+    checkout main
+    merge ak/create-fun/121 id: "gpne"
+    checkout ak/document-fun/121
+    commit id: "qrst"
+    commit id: "uvwx"
+    checkout ak/hotfix/123
+    commit id: "yzAB"
+    commit id: "CDEF" tag: "v0.6.3"
+```
+
+**Note the v0.6.3 tag is on the `ak/hotfix/123` branch at the bottom.
+
+At this point, the checks will not run on the pull request because there will be
+a conflict in the DESCRIPTION and NEWS.md files. This is okay. All you did was
+update the version numbers and add NEWS. **Do not merge at this point**. The
+next step is to release the patch.
+
+## Step 3: Release the Patch
+
+You will release the patch using the same method as described in [the releases
+chapter](release-process). You can either release on GitHub directly or via the GitHub
+CLI. Importantly, when you create the release, you should _create the release
+from the new tag_. This can be done via the GitHub interface or using GitHub's
+CLI tool.
+
+```sh
+(ak/hotfix/123)$ gh release create v0.6.3
+```
+
+## Step 4: Resolve Conflicts and Merge
+
+Now that you've created the release, you should resolve the conflicts in the
+DESCRIPTION and NEWS files and then merge it back into `main` (note: this will
+create two merge commits, but I'm only showing one in the diagram to make it
+cleaner):
+
+```{mermaid}
+gitGraph
+    commit id: "abcd"
+    commit id: "efgh" tag: "v0.6.2"
+    branch ak/create-fun/121
+    branch ak/document-fun/121
+    branch ak/hotfix/123
+    checkout main
+    checkout ak/create-fun/121
+    commit id: "ijkl"
+    commit id: "mnop"
+    checkout main
+    merge ak/create-fun/121 id: "gpne"
+    checkout ak/document-fun/121
+    commit id: "qrst"
+    commit id: "uvwx"
+    checkout ak/hotfix/123
+    commit id: "yzAB"
+    commit id: "CDEF" tag: "v0.6.3"
+    checkout main
+    merge ak/hotfix/123 id: "DeFn"
+```
+
+Now you will have the patch in place for the released version _and_ the devel
+version of this hubverse package, which means that you can continue to develop
+as normal and merge the next feature when you are ready:
+
+```{mermaid}
+gitGraph
+    commit id: "abcd"
+    commit id: "efgh" tag: "v0.6.2"
+    branch ak/create-fun/121
+    branch ak/document-fun/121
+    branch ak/hotfix/123
+    checkout main
+    checkout ak/create-fun/121
+    commit id: "ijkl"
+    commit id: "mnop"
+    checkout main
+    merge ak/create-fun/121 id: "gpne"
+    checkout ak/document-fun/121
+    commit id: "qrst"
+    commit id: "uvwx"
+    checkout ak/hotfix/123
+    commit id: "yzAB"
+    commit id: "CDEF" tag: "v0.6.3"
+    checkout main
+    merge ak/hotfix/123 id: "DeFn"
+    checkout ak/document-fun/121
+    commit id: "GHIJ"
+    commit id: "KLMN"
+    checkout main
+    merge ak/document-fun/121 id: "FnNL"
+```

--- a/docs/source/developer/index.md
+++ b/docs/source/developer/index.md
@@ -32,7 +32,7 @@ maintained by the Reich lab so hubs can synchronize data with the cloud.
 
 - <https://github.com/hubverse-org/hubverse-infrastructure#readme>
   provides an **infrastructure-as-code (IaC)** solution
-- Read more about [onboarding a hub](https://github.com/hubverse-org/hubverse-infrastructure?tab=readme-ov-file#onboarding-a-hub)
+   - Read more about [onboarding a hub](https://github.com/hubverse-org/hubverse-infrastructure?tab=readme-ov-file#onboarding-a-hub)
 - <https://github.com/hubverse-org/hubverse-transform#readme>
   performs data transformation of model output files and is deployed as an AWS
   Lambda function

--- a/docs/source/developer/index.md
+++ b/docs/source/developer/index.md
@@ -10,13 +10,12 @@ A valid hub configuration file is defined by our schemas, which are archived in
 
 There are four example hubs that can be used for testing:
 
- - <https://github.com/hubverse-org/example-simple-forecast-hub#readme>
- - <https://github.com/hubverse-org/example-complex-forecast-hub#readme>
- - <https://github.com/hubverse-org/example-simple-scenario-hub#readme>
- - <https://github.com/hubverse-org/example-complex-scenario-hub#readme>
+- <https://github.com/hubverse-org/example-simple-forecast-hub#readme>
+- <https://github.com/hubverse-org/example-complex-forecast-hub#readme>
+- <https://github.com/hubverse-org/example-simple-scenario-hub#readme>
+- <https://github.com/hubverse-org/example-complex-scenario-hub#readme>
 
 ## Projects
-
 
 ### User-facing Software
 
@@ -31,13 +30,13 @@ See [user-guide/software](../user-guide/software) for a list of these packages.
 The AWS infrastructure provides opt-in cloud storage to AWS S3 buckets
 maintained by the Reich lab so hubs can synchronize data with the cloud.
 
- - <https://github.com/hubverse-org/hubverse-infrastructure#readme>
-   provides an **infrastructure-as-code (IaC)** solution
-   - Read more about [onboarding a hub](https://github.com/hubverse-org/hubverse-infrastructure?tab=readme-ov-file#onboarding-a-hub)
- - <https://github.com/hubverse-org/hubverse-transform#readme>
-   performs data transformation of model output files and is deployed as an AWS
-   Lambda function
- - <https://github.com/hubverse-org/hubverse-cloud> provides a hub that can be used for integration tests
+- <https://github.com/hubverse-org/hubverse-infrastructure#readme>
+  provides an **infrastructure-as-code (IaC)** solution
+- Read more about [onboarding a hub](https://github.com/hubverse-org/hubverse-infrastructure?tab=readme-ov-file#onboarding-a-hub)
+- <https://github.com/hubverse-org/hubverse-transform#readme>
+  performs data transformation of model output files and is deployed as an AWS
+  Lambda function
+- <https://github.com/hubverse-org/hubverse-cloud> provides a hub that can be used for integration tests
 
 ### Dashboard
 
@@ -48,9 +47,7 @@ evaluations dashboard.
 
 A summary of the approach and tools can be found in [The Hub Dashboard project poster](https://github.com/reichlab/decisions/blob/main/project-posters/hub-dashboard/hub-dashboard.md).
 
-
 ## Processes
-
 
 ### Planning
 
@@ -68,21 +65,19 @@ This GitHub project board contains an overview of Hubverse tickets and work in p
 ### R Package Contributing and Maintenance
 
 The [`hubDevs`](https://hubverse-org.github.io/hubDevs) package is a package
-that provides tools for getting started with developing a new package in The
+that provides tools for getting started with developing a new R package in The
 Hubverse.
 
 If you want to contribute to an existing Hubverse package, please consult the
 `CONTRIBUTING.md` document for details on how to contribute.
 
-### R Package Release Process
+### Package Release Process
 
 R packages are published to The Hubverse R Universe upon minting a new GitHub
-release. This process is detailed in the
-[Introduction to the release process article](https://hubverse-org.github.io/hubDevs/dev/articles/release-process.html) in hubDevs.
-
+release. Python packages are published to PyPI. This process is detailed on the
+[release process page](release-process.md).
 
 ### Testing
 
 In-development versions R packages are tested weekly on GitHub Actions runners.
 Released versions are tested weekly in <https://github.com/hubverse-org/pkg-health-check>
-

--- a/docs/source/developer/python.md
+++ b/docs/source/developer/python.md
@@ -1,0 +1,3 @@
+# Python Release Process
+
+Details on the Hubverse Python release process coming soon.

--- a/docs/source/developer/python.md
+++ b/docs/source/developer/python.md
@@ -96,7 +96,7 @@ released version of the package.
 
 ## Releasing Python packages
 
-Unlike Cran, Python's official package index, [PyPI](https://pypi.org/), does
+Unlike CRAN, Python's official package index, [PyPI](https://pypi.org/), does
 not require manual review. Thus, the Hubverse can release Python packages
 right to PyPI without an intermediary like R-Universe. In addition,
 [TestPyPI](https://test.pypi.org/) allows us to test release processes and

--- a/docs/source/developer/python.md
+++ b/docs/source/developer/python.md
@@ -15,7 +15,7 @@ development and release process.
 
 Hubverse Python packages that will be released to PyPI must go through a
 one-time setup process as described in the
-[Creating PyPI and TestPyPI workflows](#creating-pypi-and-testpypi-workflows)
+[Creating PyPI and TestPyPI workflows](#releasing-python-packages)
 section below.
 
 Once that setup is complete, use the checklists below for updating and releasing
@@ -43,12 +43,9 @@ To update a Hubverse Python package:
   and communicated with the community.
 - [ ] Once the PR has been approved and all checks have passed, merge it.
 
-> [!TIP]
-> Review often brings up potential non-blocking features/bug fixes that are
-> orthogonal to the original PR. In these cases, instead of creating a PR to
-> merge into the original PR, it’s best to create a new issue from the PR
-> review and, after merging, create a new PR to fix that issue. This helps keep
-> disparate bugfixes and features separate.
+:::{tip}
+Review often brings up potential non-blocking features/bug fixes that are orthogonal to the original PR. In these cases, instead of creating a PR to merge into the original PR, it’s best to create a new issue from the PR review and, after merging, create a new PR to fix that issue. This helps keep disparate bugfixes and features separate.
+:::
 
 ### Release checklist
 
@@ -138,9 +135,10 @@ package's `main` branch.
 [create an environment](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment) called `pypi-test` to use for the
 TestPyPI deployment.
 
-    > [!NOTE]
-    > Because this environment is for test deployments, you don't need to add
-    > protection rules or fill out any other information when configuring it.
+    :::{note}
+    Because this environment is for test deployments, you don't need to add
+    protection rules or fill out any other information when configuring it.
+    :::
 
 2. Add the `publish-pypy-test.yaml` workflow the package's Github repo:
     - Copy the [`publish-pypi-test.yaml` workflow from hubverse-developer-actions](https://github.com/hubverse-org/hubverse-developer-actions/tree/main/publish-pypi-test/publish-pypi-test.yaml).
@@ -177,10 +175,11 @@ You will only need to do this once.
 [create an environment](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment) called `pypi` to use for the
 PyPI deployment.
 
-    > [!IMPORTANT]
-    > Because this environment will be used for publishing to production,
-    > check the `Required reviewers` option and add a list of Hubverse devs who
-    > are authorized to approve releases.
+    :::{important}
+    Because this environment will be used for publishing to production,
+    check the `Required reviewers` option and add a list of Hubverse devs who
+    are authorized to approve releases.
+    :::
 
 2. Add the `publish-pypy.yaml` workflow the package's Github repo:
     - Copy the [`publish-pypi` workflow from hubverse-developer-actions](https://github.com/hubverse-org/hubverse-developer-actions/tree/main/publish-pypi/publish-pypi.yaml).

--- a/docs/source/developer/python.md
+++ b/docs/source/developer/python.md
@@ -29,6 +29,7 @@ To update a Hubverse Python package:
 
 - [ ] Create a branch from `main` in the format of
 `<initials>/<feature>/<issue>` (_e.g._, `kj/add-bucket-versioning/111` )
+- [ ] Solve the issue, update/add test if necessary, commit, push
 - [ ] Open a pull request (PR).
   - [ ] Pull requests should be as small as possible and should focus on
     independent features.

--- a/docs/source/developer/python.md
+++ b/docs/source/developer/python.md
@@ -57,7 +57,7 @@ When it's time to release the package to PyPI:
 - [ ] Proofread `CHANGELOG.md` and change the `[unreleased]` heading at the top
 to the new release's version number. Make sure to acknowledge any contributors
 outside of the core dev team by linking to their GitHub handles.
-- [ ] Submit a PR and merge the `CHANGELOG.md` updates.
+- [ ] Submit a PR, get a review, and merge the `CHANGELOG.md` updates.
 - [ ] Create a new tag for the release as described in the
 [Hubverse Release Process](release-process.md#releases).
 - [ ] If you created the release tag locally, push it to the package's

--- a/docs/source/developer/python.md
+++ b/docs/source/developer/python.md
@@ -1,3 +1,209 @@
-# Python Release Process
+# Python Development and Releases
 
-Details on the Hubverse Python release process coming soon.
+This document describes Python-specific details about the Hubverse's
+development and release process.
+
+- [Checklists](#checklists)
+    - [Development checklist](#development-checklist)
+    - [Release checklist](#release-checklist)
+    - [Hotfix checklist](#hotfix-checklist)
+- [Releasing Python packages](#releasing-python-packages)
+    - [Overview](#overview)
+    - [TestPYPI setup](#testpypi-setup)
+    - [PyPI setup](#pypi-setup)
+    - [Add package maintainers](#add-package-maintainers)
+
+Hubverse Python packages that will be released to PyPI must go through a
+one-time setup process as described in the
+[Creating PyPI and TestPyPI workflows](#creating-pypi-and-testpypi-workflows)
+section below.
+
+Once that setup is complete, use the checklists below for updating and releasing
+the package.
+
+## Checklists
+
+### Development checklist
+
+To update a Hubverse Python package:
+
+- [ ] Create a branch from `main` in the format of
+`<initials>/<feature>/<issue>` (_e.g._, `kj/add-bucket-versioning/111` )
+- [ ] Open a pull request (PR).
+  - [ ] Pull requests should be as small as possible and should focus on
+    independent features.
+  - [ ] Each PR should include a corresponding update to the `[unreleased]`
+    section at the top of `CHANGELOG.md` (if applicable). Changelog
+    contents and style should follow the guidelines outlined in
+    [keepachangelog.com](https://keepachangelog.com/).
+  - [ ] In the PR description, include a link to the issue (_e.g._,
+    `resolves #111`) as well as any context that will help code reviewers.
+- [ ] If the PR introduces a breaking change, these changes should be tested
+  and communicated with the community.
+- [ ] Once the PR has been approved and all checks have passed, merge it.
+
+> [!TIP]
+> Review often brings up potential non-blocking features/bug fixes that are
+> orthogonal to the original PR. In these cases, instead of creating a PR to
+> merge into the original PR, it’s best to create a new issue from the PR
+> review and, after merging, create a new PR to fix that issue. This helps keep
+> disparate bugfixes and features separate.
+
+### Release checklist
+
+When it's time to release the package to PyPI:
+
+- [ ] Proofread `CHANGELOG.md` and change the `[unreleased]` heading at the top
+to the new release's version number. Make sure to acknowledge any contributors
+outside of the core dev team by linking to their GitHub handles.
+- [ ] Submit a PR and merge the `CHANGELOG.md` updates.
+- [ ] Create a new tag for the release as described in the
+[Hubverse Release Process](release-process.md#releases).
+- [ ] If you created the release tag locally, push it to the package's
+repository (for example, `git push v0.2.4`).
+
+### Hotfix checklist
+
+A hotfix is a bug fix that is independent from in-development features and
+needs to be deployed within a day. Details on hotfixes can be found on the
+[hotfix page](hotfix.md).
+
+To patch and release a hotfix:
+
+- [ ] Create a new branch from the latest tag using pattern
+`<initials>/hotfix/<issue>`
+
+    ```sh
+    (main)$ git switch --detach 0.14.0 # checkout the tag
+    ((0.14.0))$ git switch -c znk/hotfix/143 # create a new branch
+    (znk/hotfix/143)$
+    ```
+
+- [ ] Write a test, fix the bug, and update `CHANGELOG.md` with the
+[patch version](release-process.md#patch) and description. Push these changes
+upstream:
+
+    ```sh
+    (znk/hotfix/143)$ git commit -m 'hotfix for #143'
+    (znk/hotfix/143)$ git push -u origin znk/hotfix/143 # push the hotfix
+    ```
+
+- [ ] Create a PR, get a review, and confirm that tests pass against the
+released version of the package.
+- [ ] From the hotfix branch, create a tag for the release.
+- [ ] Resolve conflicts in the PR and merge into main.
+
+## Releasing Python packages
+
+Unlike Cran, Python's official package index, [PyPI](https://pypi.org/), does
+not require manual review. Thus, the Hubverse can release Python packages
+right to PyPI without an intermediary like R-Universe. In addition,
+[TestPyPI](https://test.pypi.org/) allows us to test release processes and
+tools without publishing to the real index.
+
+The documentation below assumes that Hubverse PyPI packages will be released
+to PyPI, allowing us to follow the "main = stable dev branch" release process
+as outlined in the [Hubverse release process](release-process.md).
+
+### Overview
+
+PyPI (and TestPyPI) allow
+[_trusted publishers_](https://docs.pypi.org/trusted-publishers/) as way to
+publish packages via GitHub actions without embedding secrets in the project
+repository.
+
+Any Hubverse Python packages published to PyPI will use trusted publishing,
+which protects against supply chain attacks and credential leaks.
+
+- merges to the stable dev branch (`main`) will be released on TestPyPI as an end-to-end test
+- adding a release tag to the repo (_i.e._, vX.Y.Z) will trigger a release to PyPI
+
+This article contains a clearly-written deep dive into
+[how trusted publishing works and the advantages of using it](https://blog.trailofbits.com/2023/05/23/trusted-publishing-a-new-benchmark-for-packaging-security/).
+
+### TestPYPI setup
+
+Once you complete the GitHub and TestPYPI setup as outlined below, the new
+Hubverse package will be pushed to TestPyPI automatically. You will only need
+to do this once.
+
+Publishing to TestPyPI doesn't release the software. Instead, it's a way to test
+the end-to-end publication process each time a new update is merged to the
+package's `main` branch.
+
+#### GitHub
+
+1. In the package's GitHub repo,
+[create an environment](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment) called `pypi-test` to use for the
+TestPyPI deployment.
+
+    > [!NOTE]
+    > Because this environment is for test deployments, you don't need to add
+    > protection rules or fill out any other information when configuring it.
+
+2. Add the `publish-pypy-test.yaml` workflow the package's Github repo:
+    - Copy the [`publish-pypi-test.yaml` workflow from hubverse-developer-actions](https://github.com/hubverse-org/hubverse-developer-actions/tree/main/publish-pypi-test/publish-pypi-test.yaml).
+    - Change `<package>` in the TestPyPI url to the name of your package
+    (_e.g._, `https://test.pypi.org/p/hubDataPy`)
+
+#### TestPyPI
+
+1. [Create a TestPyPI account](https://test.pypi.org/account/register/) if you
+don't already have one.
+2. Log in to TestPyPI.
+3. [Create a new Trusted Publisher](https://test.pypi.org/manage/account/publishing/)
+for the Hubverse package.
+    - PyPI Project Name: name in the `[project]` section of the package's
+    `pyproject.toml` file
+    - Owner: GitHub organization name (`hubverse-io`)
+    - Repository name: the package's GitHub repository name
+    - Workflow name: full file name of the GitHub workflow that publishes to
+    TestPyPI (_e.g._ `publish-pypi-test.yaml`)
+    - Environment name: name of the GitHub environment created above
+    (`pypi-test`)
+
+### PyPI setup
+
+Once you complete the GitHub and PyPI setup as outlined below, your package will
+be published to PyPI whenever a new release tag is pushed to the package's
+repository.
+
+You will only need to do this once.
+
+#### GitHub
+
+1. In the package's GitHub repo,
+[create an environment](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment) called `pypi` to use for the
+PyPI deployment.
+
+    > [!IMPORTANT]
+    > Because this environment will be used for publishing to production,
+    > check the `Required reviewers` option and add a list of Hubverse devs who
+    > are authorized to approve releases.
+
+2. Add the `publish-pypy.yaml` workflow the package's Github repo:
+    - Copy the [`publish-pypi` workflow from hubverse-developer-actions](https://github.com/hubverse-org/hubverse-developer-actions/tree/main/publish-pypi/publish-pypi.yaml).
+    - Change `<package>` in the PyPI url to the name of your package
+    (_e.g._, `https://pypi.org/p/hubDataPy`)
+
+#### PyPI
+
+1. [Create a PyPI account](https://pypi.org/account/register/) if you
+don't already have one.
+2. Log in to PyPI.
+3. [Create a new Trusted Publisher](https://pypi.org/manage/account/publishing/)
+for the Hubverse package:
+    - PyPI Project Name: name in the `[project]` section of the package's
+    `pyproject.toml` file
+    - Owner: GitHub organization name (`hubverse-io`)
+    - Repository name: the package's GitHub repository name
+    - Workflow name: full file name of the GitHub workflow that publishes to
+    PyPI (_e.g._ `publish-pypi.yaml`)
+    - Environment name: name of the GitHub environment created above
+    (`pypi`)
+
+### Add package maintainers
+
+To ensure continuity, it's important that Hubverse packages on both PyPI and
+TestPYPI have multiple maintainers and collaborators. You can add other Hubverse
+devs to these roles from the project's _Collaborators_ page on PyPI/TestPyPI.

--- a/docs/source/developer/r.md
+++ b/docs/source/developer/r.md
@@ -1,0 +1,4 @@
+# R Release Process
+
+The `hubDevs` package contains a
+[Release Checklist for R packages](https://hubverse-org.github.io/hubDevs/articles/release-checklists.html).

--- a/docs/source/developer/release-process.md
+++ b/docs/source/developer/release-process.md
@@ -1,0 +1,366 @@
+# Hubverse Release Process
+
+Parts of this document are adapted for The Hubverse from
+[The Carpentries Developer's Handbook](https://carpentries.github.io/workbench-dev/releases.html) (c) The Carpentries under the [CC-BY 4.0 license](https://creativecommons.org/licenses/by/4.0/).
+
+**Looking for a checklist?**
+
+- [R package release checklist](r.md)
+- [Python package release checklist](python.md)
+
+## Executive Summary
+
+The release process is now a general workflow that can help to reduce the size
+of pull requests:
+
+1. Iterate on small bug fixes and PRs on branches, merging into main as a
+   stable development branch
+2. When ready, bump the version, add an annotated git tag, and release
+3. Bump the version in `main` back to a development version
+
+This workflow applies to both R and Python packages, although the implementation
+specifics will vary between languages.
+
+## Background
+
+While the release process described here applies to both R and Python, the
+impetus for adopting it was making the Hubverse R packages available on the
+[Hubverse R-Universe][r-universe]. R-Universe checks for new versions hourly,
+which allows users to get up-to-date packages without running out of GitHub API
+query attempts.
+
+The Hubverse does not have a Python equivalent to the R-Universe. Instead,
+Python packages are distributed via [PyPI](https://pypi.org/), Python's package
+index.
+
+In order to maintain quality, packages are only sent to the R-Universe or PyPi
+if they have been formally released on GitHub. This allows us to add new
+experimental, non-breaking features incrementally, without changing the stable
+deployments.
+
+### Previous state
+
+Prior to updating the Hubverse release process in August 2024, **each pull
+request merged to the `main` branch of a repository effectively meant the
+release of a new version**. Ideally, this meant that our Git history would look
+like a series of adjacent belt loops:
+
+```mermaid
+gitGraph
+    commit id: "abcd"
+    commit id: "efgh (0.14.0)"
+    branch feature1
+    checkout main
+    checkout feature1
+    commit id: "ijkl"
+    commit id: "mnop"
+    checkout main
+    merge feature1 id: "gpne (0.14.1)"
+    branch feature2
+    checkout feature2
+    commit id: "qrst"
+    commit id: "uvwx"
+    checkout main
+    merge feature2 id: "punx (0.14.2)"
+```
+
+However, a pattern often emerges where more than one feature in a particular
+release is desired and, because we release directly to `main`, the graph looks
+like a thundercloud:
+
+```mermaid
+gitGraph
+    commit id: "abcd"
+    commit id: "efgh (0.14.0)"
+    branch feature1
+    checkout main
+    checkout feature1
+    commit id: "ijkl"
+    commit id: "mnop"
+    branch feature2
+    checkout feature2
+    commit id: "qrst"
+    checkout feature1
+    commit id: "uvwx"
+    checkout feature2
+    commit id: "yz12"
+    checkout feature1
+    merge feature2 id: "xu12"
+    checkout main
+    merge feature1 id: "gpxe (0.14.1)"
+```
+
+The problem with the second graph is that, as the number of extra features grows,
+the size of the PR that will be the release becomes larger and larger.
+Moreover, the exact changes that were needed in the original PR are mixed in
+with all the changes from the child branches, meaning that it is more difficult
+to retrospectively review that PR.
+
+### New release process
+
+The release process adopted in August 2024 alleviates the "many features =
+large PR" problem and makes it easier to multiple people to work on package
+features simultaneously.
+
+Now that we distribute packages outside of GitHub itself, builds can be pinned
+to Releases on specific tags, resulting in a git graph that looks similar to
+[the first graph](#previous-state), but it can also **enable developers to work in parallel**
+on independent features, allowing users to intermittently test these features by
+installing from the default branch in GitHub.
+
+```mermaid
+gitGraph
+    commit id: "abcd"
+    commit id: "efgh" tag: "0.14.0"
+    branch feature1
+    branch feature2
+    checkout main
+    checkout feature1
+    commit id: "ijkl"
+    commit id: "mnop"
+    checkout main
+    checkout feature2
+    commit id: "qrst"
+    commit id: "uvwx"
+    checkout main
+    merge feature1 id: "gpne"
+    merge feature2 id: "punx"
+    branch release
+    checkout release
+    commit id: "2zy1"
+    checkout main
+    merge release id: "1u2n" tag: "0.14.1"
+```
+
+## Versioning
+
+The hubverse is built using very basic semantic versioning using the
+`X.Y.Z` pattern. Development versions are indicated as
+
+- `X.Y.Z[.9000]` for R
+- `X.Y.Z[.dev<n>]` for Python.
+
+Here's an example for an R package. If we take
+[the previous git graph](#new-release-process) and labelled the version number,
+you can see how the first release in our graph was a minor release, followed by
+a patch release. Everything that has [a `.9000` attached
+is considered in-development](#dev). Read below for details and examples of
+each of these semantic versions:
+
+```mermaid
+gitGraph
+    commit id: "abcd (0.13.2.9000)"
+    commit id: "efgh (0.14.0)" tag: "0.14.0"
+    branch feature1
+    branch feature2
+    checkout main
+    checkout feature1
+    commit id: "ijkl (0.14.0.9000)"
+    commit id: "mnop (0.14.0.9000)"
+    checkout main
+    checkout feature2
+    commit id: "qrst (0.14.0.9000)"
+    commit id: "uvwx (0.14.0.9000)"
+    checkout main
+    merge feature1 id: "gpne (0.14.0.9000)"
+    merge feature2 id: "punx (0.14.0.9000)"
+    branch release
+    checkout release
+    commit id: "2zy1 (0.14.1)"
+    checkout main
+    merge release id: "1u2n (1.14.1)" tag: "0.14.1"
+```
+
+<a id="major">`X`</a>
+: **Major version number**: this version number will change if there are
+  significant breaking changes to any of the user-facing workflows. That is, if
+  a change requires users to modify their scripts, then it is a breaking change.
+  **EXAMPLE**: There are no examples of hubverse packages undergoing a major
+  version change, but [schemas v3.0.0](https://github.com/hubverse-org/schemas/releases/tag/v3.0.0)
+  included the breaking change of switching `sample/output_type_id` (an array)
+  to `sample/output_type_id_params` (an object). The breaking change meant that
+  it was a non-trivial task to switch from a `v2.0.1` schema to `v3.0.0` and the
+  users. This was reflected in the month-long timeline between [the
+  announcement of the change on
+  2024-05-13](https://github.com/orgs/hubverse-org/discussions/13) to the
+  actual release on 2024-06-18.
+
+<a id="minor">`Y`</a>
+: **Minor version number**: this version number will change if there are new
+  features or enhanced behaviors available to the users in a way that _does not
+  affect how users who do not need the new features use the package_. This
+  number grows the fastes in early stages of development.
+  **EXAMPLE**: The [`{hubValidations}` package version 0.5.0](https://hubverse-org.github.io/hubValidations/news/index.html#hubvalidations-050)
+  gives users the ability to reduce compute time by allowing them to sub-set
+  the configuration by the new `output_type` argument to
+  `expand_model_out_grid()`. Users who change nothing in their workflows or
+  scripts will not see any change for the better or worse.
+
+<a id="patch">`Patch`</a>
+: **Patch version number**: this version number will change if something that
+  was previously broken was fixed, but no new features have been added.
+  **EXAMPLE**: the `{hubAdmin}` package needed an enhancement for schema version
+  3.0.1, which removed the requirements for `CDF` outputs to have a specific
+  pattern. [The actual fix was not something a user would interact
+  with](https://github.com/hubverse-org/hubAdmin/pull/29/files#diff-c55622c612385015eaf6d6c2a48e72daae1caa20c58b9531493d74cbaf903f96),
+  so [version 1.0.1](https://hubverse-org.github.io/hubAdmin/news/index.html#hubadmin-101)
+  was a patch release.
+
+<a id="dev">dev versioning</a>
+: **Development version indicator**: this version number indicates that the
+  package is in a development state and has the potential to change. When it's on
+  the `main` branch, it indicates that the features or patches introduced have
+  been reviewed and tested. This version is _appended after every successful
+  release_. When this development version indicator exists, the documentation
+  site will have an extra `dev/` directory that contains the upcoming changes
+  so that we can continue to develop the hubverse without disrupting the
+  regular documentation flow.
+
+- For R packages, advice on incrementing the version number from
+  [The R Packages Book (Wickham and Bryan, 2023)](https://r-pkgs.org/lifecycle.html#sec-lifecycle-version-number-tidyverse):
+
+    > Increment the development version, e.g. from 9000 to 9001, if you’ve
+    > added an important feature and you (or others) need to be able to
+    > detect or require the presence of this feature. For example, this can
+    > happen when two packages are developing in tandem. This is generally
+    > the only reason that we bother to increment the development version.
+    > This makes in-development versions special and, in some sense,
+    > degenerate. Since we don’t increment the development component with
+    > each Git commit, the same package version number is associated with
+    > many different states of the package source, in between releases.
+
+- For Python packages, we use [`setuptools-scm`](https://setuptools-scm.readthedocs.io/en/latest/)
+  to calculate and apply versions automatically, including the version numbers
+  for incremental development releases. When it's added to a Python package
+  (via the `pyproject.toml` file), `setuptools-scm` inspects git tags and
+  dynamically sets the version number as
+  [described in its documentation](https://setuptools-scm.readthedocs.io/en/latest/usage/#default-versioning-scheme).
+
+## Release Process
+
+The sections below outline a general release process for both R and Python
+packages. For language-specific checklists, refer to:
+
+- [R release process](r.md)
+- [Python release process](python.md)
+
+### Non-urgent releases only
+
+This release process assumes that we have accumulated bugfixes and/or features
+in the `main` branch, which we are ready to release. If you have a bug that
+needs to be patched _immediately_ and you have new features in the main branch
+that are not yet ready to be released, then you should [create a
+hotfix](hotfix.md) instead.
+
+### Releases
+
+Releases are a concept that is specific for GitHub. Under the hood, releases are
+created from commits or tags. When you use the GitHub web interface, you can
+choose to have a tag automatically created from a release (though the tag will
+not be annotated or signed, see below for creating stronger, signed tags). All
+releases should contain a summary of the changes that happened between this
+version and the previous version. A good example of this are [the hubverse
+schema release notes](https://github.com/hubverse-org/schemas/releases), and
+GitHub offers to automatically fill the release notes with titles and links to
+the pull requests that populated the release, which is a good summary (assuming
+people create good PR titles).
+
+Once the release is created on GitHub, R packages will be available on the
+R-Universe in about an hour or less. Python packages are released to PyPI via
+a GitHub workflow that runs when a release tag is added to the repo.
+
+#### Signed Tags
+
+It is good practice to create a tag to release from so that we have a way to
+track the releases even if we eventually move away from GitHub. Better practice
+is to create _annotated_ tags with the `-a` flag, which adds metadata to the
+tag, meaning that it cannot be moved. Even better practice is to create
+_signed_ tags with the `-s` flag, which adds a cryptographic signature to the
+annotated tag metadata that allows anyone to verify that it came from your
+computer and not someone pretending to be you.
+
+Zhian likes to create tags via the command line because he has set up his git
+configuration to use [a gpg signature](https://gist.github.com/phortuin/cf24b1cca3258720c71ad42977e1ba57)
+so the tags and the releases are both verified. Recently, Git and GitHub added
+support for [creating signatures via an SSH key](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification), which is _a lot_ more approchable than GPG.
+
+Unfortunately, you cannot create a signed tag on the GitHub web interface and it
+must be done locally.
+
+```sh
+git tag -s X.Y.Z -m 'summary of changes'
+git push --tags
+```
+
+Once you have a signed tag created, you can then go to the Releases tab on
+GitHub and create the release (or you can use the `gh` CLI utility and run
+`gh release create X.Y.Z` to interactively create the release).
+
+### R: Releasing to CRAN
+
+R-Universe is not the official R package index—CRAN is. If you want to release
+a package to CRAN, it's a relatively straightforward process that takes five
+minutes on your part as the maintainer.
+
+The time between sending your package to CRAN and the time it becomes available
+to the public usually ranges anywhere from 30 minutes to two or three days,
+depending on volume and feedback from CRAN maintainers. Because CRAN submissions
+are often a back and forth process, you should not tag your release until you
+have confirmed that CRAN has accepted the submission.
+
+Some tips for CRAN submissions:
+
+- Your first submission will likely take the longest (see [Chapter 22 of R Packages by Wickham and Bryan](https://r-pkgs.org/release.html#sec-release-initial))
+- Don't use the webform; use [`devtools::release()`](https://devtools.r-lib.org/reference/release.html)
+- Remove the `Remotes:` items in the DESCRIPTION with:
+
+    ```sh
+    sed -i '' -E -e '/(Remotes:|  hubverse-org)/d' DESCRIPTION
+    ```
+
+(you will restore this later with  `git restore DESCRIPTION`). [^uncommitted]
+
+- Commit the `CRAN_SUBMISSION` file when it changes
+- There is a missing stair that can make submissions unpleasant.
+If you get a nasty review from Ripley, contact one of the other hubverse maintainers for backup/strategy/comiseration.
+
+[^uncommitted]: You will get a warning from devtools saying that all files should be tracked and committed before release.
+  Double check that all that changed was removing the `Remotes:` field from the
+  DESCRIPTION and proceed.
+
+## Testing
+
+Packages will exist in two states: released and stable development. Both of
+these states need to pass checks (for example, `R CMD check`, tests, and
+coverage), but the challenge with two versions becomes: how do you ensure both
+versions work with both versions of the other packages?
+
+The strategy is three-fold:
+
+- All packages in development are tested against development packages. It is
+important to remember that development versions must also not introduce
+breaking changes. Testing breaking changes should be performed in a separate
+branch.
+- On a release/hotfix, pull request, all packages are tested against the
+released packages to ensure no regressions.
+- All packages (released and devel) are tested weekly. This helps to avoid
+surprise reverse-dependency problems.
+
+### R Testing
+
+For R packages, testing against the development versions is achieved by setting
+[the `Remotes:` section in your DESCRIPTION file](https://r-pkgs.org/dependencies-in-practice.html#sec-dependencies-nonstandard);
+this ensures that when dependencies are installed for the GitHub workflow run,
+the hubverse dependencies are installed from GitHub and not the R-universe.
+
+During releases and hotfixes (detected by checking that the branch name
+contains either `/release/` or  `/hotfix/`, the remote declarations of hubverse
+packages are removed (before the dependencies are installed) with the command
+`sed -i "" -E -e '/[ ][ ]hubverse-org/d' DESCRIPTION`.
+
+[r-universe]: https://hubverse-org.r-universe.dev/'
+
+### Python Testing
+
+At the time of this writing, the Hubverse does not have a documented process
+for testing Python packages against development versions.

--- a/docs/source/developer/release-process.md
+++ b/docs/source/developer/release-process.md
@@ -358,7 +358,7 @@ contains either `/release/` or  `/hotfix/`, the remote declarations of hubverse
 packages are removed (before the dependencies are installed) with the command
 `sed -i "" -E -e '/[ ][ ]hubverse-org/d' DESCRIPTION`.
 
-[r-universe]: https://hubverse-org.r-universe.dev/'
+[r-universe]: https://hubverse-org.r-universe.dev/
 
 ### Python Testing
 

--- a/docs/source/developer/release-process.md
+++ b/docs/source/developer/release-process.md
@@ -108,7 +108,7 @@ to Releases on specific tags, resulting in a git graph that looks similar to
 on independent features, allowing users to intermittently test these features by
 installing from the default branch in GitHub.
 
-```mermaid
+```{mermaid}
 gitGraph
     commit id: "abcd"
     commit id: "efgh" tag: "0.14.0"

--- a/docs/source/developer/release-process.md
+++ b/docs/source/developer/release-process.md
@@ -45,7 +45,7 @@ request merged to the `main` branch of a repository effectively meant the
 release of a new version**. Ideally, this meant that our Git history would look
 like a series of adjacent belt loops:
 
-```mermaid
+```{mermaid}
 gitGraph
     commit id: "abcd"
     commit id: "efgh (0.14.0)"

--- a/docs/source/developer/release-process.md
+++ b/docs/source/developer/release-process.md
@@ -68,7 +68,7 @@ However, a pattern often emerges where more than one feature in a particular
 release is desired and, because we release directly to `main`, the graph looks
 like a thundercloud:
 
-```mermaid
+```{mermaid}
 gitGraph
     commit id: "abcd"
     commit id: "efgh (0.14.0)"

--- a/docs/source/developer/release-process.md
+++ b/docs/source/developer/release-process.md
@@ -321,8 +321,11 @@ Some tips for CRAN submissions:
 (you will restore this later with  `git restore DESCRIPTION`). [^uncommitted]
 
 - Commit the `CRAN_SUBMISSION` file when it changes
-- There is a missing stair that can make submissions unpleasant.
-If you get a nasty review from Ripley, contact one of the other hubverse maintainers for backup/strategy/comiseration.
+
+:::{tip}
+If you get an unhelpful or nasty review from a CRAN administrator, contact one of the other Hubverse maintainers who has experience submitting to CRAN (i.e. Zhian) for backup/strategy/comiseration. You can also see if you ran into a common issue by checking [The CRAN Cookbook](https://contributor.r-project.org/cran-cookbook/)
+:::
+
 
 [^uncommitted]: You will get a warning from devtools saying that all files should be tracked and committed before release.
   Double check that all that changed was removing the `Remotes:` field from the

--- a/docs/source/developer/release-process.md
+++ b/docs/source/developer/release-process.md
@@ -147,7 +147,7 @@ a patch release. Everything that has [a `.9000` attached
 is considered in-development](#dev). Read below for details and examples of
 each of these semantic versions:
 
-```mermaid
+```{mermaid}
 gitGraph
     commit id: "abcd (0.13.2.9000)"
     commit id: "efgh (0.14.0)" tag: "0.14.0"

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -106,6 +106,10 @@ user-guide/presentations.md
 :caption: Developer Guide
 :hidden:
 developer/index.md
+developer/release-process.md
+developer/hotfix.md
+developer/r.md
+developer/python.md
 ```
 
 ```{toctree}


### PR DESCRIPTION
Closes #233 

This PR adds documentation for release Python-based Hubverse packages. 

It also moves some of the release documents from `hubDevs` to the official hubverse documentation. See comments on the above issue for more details.

This PR can be reviewed commit by commit.

**Update 2025-01-30**
The following pages are moving here from `hubDevs`, where they've already been published. This PR makes some light edits, but most of the content is unchanged.

- `hotfix.md`
- `release-process.md`

The big addition is `python.md`, which is new and describes the Hubverse process for publishing Python packages. Most of it is based on my experience with publishing the Reich Lab's cladetime package.

