### PR TITLE
Bump the minimum Python version required for this project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
 license = {text = "MIT License"}
 dynamic = ["version"]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 
 dependencies = [


### PR DESCRIPTION
When testing out the new Python setup instructions, we learned that the [requirements aren't compatible with Python 3.9](https://github.com/hubverse-org/hubDocs/pull/235#discussion_r1923216206).

❓Curious to hear thoughts about PRs that don't link to a GitHub issue. For very small updates like this one, sometimes I skip making an issue, but can create one if needed.
