### PR TITLE
Bump all Python requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 alabaster==1.0.0
     # via sphinx
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   starlette
     #   watchfiles
@@ -45,6 +45,7 @@ imagesize==1.4.1
     # via sphinx
 jinja2==3.1.6
     # via
+    #   hubdocs (pyproject.toml)
     #   myst-parser
     #   sphinx
 markdown-it-py==3.0.0
@@ -57,17 +58,19 @@ mdit-py-plugins==0.4.2
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-myst-parser==4.0.0
+myst-parser==4.0.1
     # via hubdocs (pyproject.toml)
 nodeenv==1.9.1
     # via pre-commit
 packaging==24.2
-    # via sphinx
-platformdirs==4.3.6
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+platformdirs==4.3.7
     # via virtualenv
 pre-commit==4.2.0
     # via hubdocs (pyproject.toml)
-pydata-sphinx-theme==0.16.1
+pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
 pygments==2.19.1
     # via
@@ -81,13 +84,15 @@ pyyaml==6.0.2
     #   sphinxcontrib-mermaid
 requests==2.32.3
     # via sphinx
+roman-numerals-py==3.1.0
+    # via sphinx
 sniffio==1.3.1
     # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.6
     # via beautifulsoup4
-sphinx==8.1.3
+sphinx==8.2.3
     # via
     #   hubdocs (pyproject.toml)
     #   myst-parser
@@ -98,7 +103,7 @@ sphinx==8.1.3
     #   sphinxcontrib-mermaid
 sphinx-autobuild==2024.10.3
     # via hubdocs (pyproject.toml)
-sphinx-book-theme==1.1.3
+sphinx-book-theme==1.1.4
     # via hubdocs (pyproject.toml)
 sphinx-design==0.6.1
     # via hubdocs (pyproject.toml)
@@ -119,12 +124,14 @@ sphinxcontrib-serializinghtml==2.0.0
 starlette==0.46.1
     # via sphinx-autobuild
 typing-extensions==4.12.2
-    # via pydata-sphinx-theme
+    # via
+    #   beautifulsoup4
+    #   pydata-sphinx-theme
 urllib3==2.3.0
     # via requests
 uvicorn==0.34.0
     # via sphinx-autobuild
-virtualenv==20.29.0
+virtualenv==20.29.3
     # via pre-commit
 watchfiles==1.0.4
     # via sphinx-autobuild


### PR DESCRIPTION
This replaces PR #275, which failed a readthedocs build due to incompatible dependencies. We've seen this pattern in a few other Python- based projects after enabling Dependabot. Because it's limited to 5 PRs at a time, it sometimes submits updates to one package that cannot be resolved in isolation from other package updates.

This changeset bumps all remaining Python dependencies at once. If this pattern persists, we can tweak the Dependabot settings and use "group".