### PR TITLE
Tell dependabot to consolidate minor dependency updates into a single

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,28 @@
-# instruct GitHub dependabot to check for updates to Python dependencies
+# instruct GitHub dependabot to scan github actions and Python code for dependency updates
+
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    # variant-nowcast-hub data pipeline scripts are in `src`
-    directory: "/requirements/"
+  - package-ecosystem: "github-actions"
+    # dependabot automatically checks .github/workflows/ and .github/actions/
+    directory: "/"
     schedule:
       interval: "weekly"
+    # group all run-of-the mill updates into a single pull request
+    groups:
+      gha-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # group all run-of-the mill updates into a single pull request
+    groups:
+      py-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor


### PR DESCRIPTION
To reduce the amount of "noise" from Dependabot-submitted pull requests, this changeset adds a "groups" setting to dependabot.yaml. More information about the groups setting:
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--

The changeset also changes the "pip" package-ecosystem directory from "requirements" to the repo's root, where pyproject.toml is located.