### PR TITLE
Update the cloud onboarding section of Hubverse dev docs

### DIFF
--- a/docs/source/developer/cloud-onboarding.md
+++ b/docs/source/developer/cloud-onboarding.md
@@ -1,4 +1,4 @@
-# AWS Onboarding
+# AWS Onboarding (and Offboarding)
 
 The Hubverse team currently provides cloud hosting for hubs. A "cloud-enabled" hub is one that
 mirrors its data and configuration to an Amazon Web Services (AWS) S3 bucket. By default, the current
@@ -11,7 +11,7 @@ hub directories are synced in near-real-time to AWS:
 - model-output
 - target-data
 
-## Setup
+## Cloud Onboarding Setup
 
 Because each hub has its own S3 bucket and other dedicated AWS resources, a member of the Hubverse team needs to be
 involved in cloud onboarding.
@@ -19,7 +19,8 @@ involved in cloud onboarding.
 If a hub admin wants to enable cloud hosting, these are the steps to follow:
 
 1. Decide on a name for the hub's S3 bucket. S3 bucket names must follow
-   Amazon's [bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) and be globally unique.
+   Amazon's
+   [bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) and be globally unique.
 2. Create the hub's AWS resources by following instructions in the
    [`hubverse-infrastructure` README](https://github.com/hubverse-org/hubverse-infrastructure/blob/main/README.md#onboarding-a-hub-to-aws).\
     **Note:** Don't be intimidated by "creating AWS resources." The process is automated and requires a three line
@@ -72,3 +73,21 @@ sequenceDiagram
     B->>hc: query hub data
     hc->>B: return data
 ```
+
+## Cloud Offboarding
+
+Removing a hub from Hubverse AWS hosting is essentially a reverse of the onboarding
+process, with a few caveats.
+
+1. Update the hub's `admin.json` file, setting the `cloud.enabled` value to false. \
+   **Note:** You can also remove the entire `cloud` section if you prefer.
+2. **Optional:** Remove the `hubverse-aws-upload.yaml` workflow file from the hub.
+   Leaving this workflow intact won't harm anything because it checks `admin.json`
+   for `cloud.enabled` = true before syncing data to AWS.
+3. To completely remove the hub's AWS resources:
+
+  - Manually delete the contents of the hub's S3 bucket (AWS does not
+    permit deleting S3 buckets that contain objects).
+  - Submit a PR to [`hubverse-infrastructure`](https://github.com/hubverse-org/hubverse-infrastructure)
+    that removes the hub from the `hubs.yaml` file.
+  - Once the PR is merged, the hub's AWS resources will be deleted.


### PR DESCRIPTION
This PR adds a section about offboarding hubs (mostly as a reminder that the contents of an S3 bucket need to be removed before the bucket itself can be deleted)