### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Documentation for Collaborative Modeling Hubs
 
 This repository includes the content needed to generate the [Hubverse static
-documentation site](https://hubverse.io/en/latest/). The website includes documentation
+documentation site](https://docs.hubverse.io/en/latest/). The website includes documentation
 about how to build, manage, and maintain collaborative modeling hubs.
 
 Below you can find instructions on how to build and edit the Hubverse
@@ -22,7 +22,7 @@ documentation site locally on your computer.
 This site uses [ReadTheDocs](https://readthedocs.org/) and
 [Sphinx](https://www.sphinx-doc.org/en/master/index.html) for building and
 maintaining the content. The
-[live version of the website can be found in this page](https://hubverse.io/en/latest/).
+[live version of the website can be found in this page](https://docs.hubverse.io/en/latest/).
 
 Useful links:
 

--- a/docs/_static/js/custom.js
+++ b/docs/_static/js/custom.js
@@ -1,6 +1,6 @@
 // _static/custom.js
 
-// Default Statcounter code for hubverse https://hubverse.io/
+// Default Statcounter code for hubverse https://docs.hubverse.io/
 var sc_project = 13009474;
 var sc_invisible = 1;
 var sc_security = "3d034fb6";

--- a/docs/source/developer/cloud-onboarding.md
+++ b/docs/source/developer/cloud-onboarding.md
@@ -27,7 +27,7 @@ If a hub admin wants to enable cloud hosting, these are the steps to follow:
     config change.
 3. Once the AWS resources are in place, submit a PR to the hub:
     - Add a `cloud` section to the `admin.json` file. See the
-      [Hubverse schema documentation](https://hubverse.io/en/latest/user-guide/hub-config.html#hub-administrative-configuration-admin-json-interactive-schema)
+      [Hubverse schema documentation](https://docs.hubverse.io/en/latest/user-guide/hub-config.html#hub-administrative-configuration-admin-json-interactive-schema)
       for more details.
     - Add the [`hubverse-aws-upload.yaml` GitHub workflow file](https://github.com/hubverse-org/hubverse-actions/blob/main/hubverse-aws-upload/hubverse-aws-upload.yaml).
       This is a Hubverse-maintained workflow that runs after a PR is merged to the hub's `main` branch. You do not need

--- a/docs/source/user-guide/target-data.md
+++ b/docs/source/user-guide/target-data.md
@@ -161,7 +161,7 @@ rates or a human-readable translation of codes.
 
 Oracle output follows a format that is similar to a [hubverse model
 output
-file](https://hubverse.io/en/latest/user-guide/model-output.html#example-model-submission-file),
+file](https://docs.hubverse.io/en/latest/user-guide/model-output.html#example-model-submission-file),
 with three main differences:
 
 - Predictions correspond to a distribution that places probability 1 on


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.