### PR TITLE
Add dashboard site documentation 

### DIFF
--- a/docs/source/developer/dashboard-local.md
+++ b/docs/source/developer/dashboard-local.md
@@ -405,6 +405,7 @@ There are two steps:
    ```
 
 :::{admonition} Building with remote data
+(dashboard-local-remote)=
 
 There are two modes for the site to ingest data
 
@@ -420,12 +421,12 @@ a user and repo name:
 
 ```bash
 docker run --rm -it \
- --platform=linux/amd64 \
- -v "$dash":"/site" \
- ghcr.io/hubverse-org/hub-dash-site-builder:latest \
- render.sh \
- -u "reichlab" -r "flu-metrocast"
- -o "_site"
+  --platform=linux/amd64 \
+  -v "$dash":"/site" \
+  ghcr.io/hubverse-org/hub-dash-site-builder:latest \
+  render.sh \
+  -u "reichlab" -r "flu-metrocast"
+  -o "_site"
 ```
 
 This will produce the same site that you can view locally, but it will no
@@ -437,6 +438,7 @@ restricts usage to public repositories.
 
 :::
 
+For deeper dive into what is happening in this process, visit [How the website is built (a tale of two sources)](#dashboard-site-build).
 
 (dashboard-local-preview)=
 ## Previewing the site

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -15,18 +15,6 @@ was designed under the following motivations:
    should not need to handle any templating that cannot be easily automated.
 4. We should not have to maintain a server to deploy these sites.
 
-## References
-
-Here are links to some concepts that are used in the website builder.
-
-- [Building a website using quarto](https://quarto.org/docs/websites/)
-- [BASH scripting cheat sheet](https://devhints.io/bash)
-- `yq` [tips and tricks](https://mikefarah.gitbook.io/yq/usage/tips-and-tricks)
-  and [recipes](https://mikefarah.gitbook.io/yq/recipes). Specific operators
-  can be found in the comments of the
-  [`modify-quarto-yml.sh`](https://github.com/hubverse-org/hub-dash-site-builder/tree/main/modify-quarto-yml.sh)
-  file in the hub-dash-site-builder repository.
-- [Dockerfile reference](https://docs.docker.com/reference/dockerfile/)
 
 ## Installation
 
@@ -45,7 +33,56 @@ is the result of a combination of two sources:
 1. [dashboard website builder `static/` directory](https://github.com/hubverse-org/hub-dash-site-builder/tree/main/static) and,
 2. [the dashboard repository](https://github.com/hubverse-org/hub-dashboard-template/)
 
-For example, the [source for the hub-dashboard-template website](https://github.com/hubverse-org/hub-dashboard-template/tree/gh-pages), shows the following files and folders.
+### Configuring the site
+
+#### Minimal configuration
+
+At the bare minimum, a dashboard source repository should contain two files:
+
+ 1. `site-config.yml` that has two required fields:
+    - `hub`, the name of the hub
+    - `pages`, a list of files in `pages/` to include, which should have `index.qmd`.
+ 2. `pages/index.qmd`
+
+These two files will create a website that has a single page and is,
+admittedly, not very useful other than providing basic information about a hub
+with a link to it. However, the user has different options available to them.
+
+#### Options for the site
+
+ - **Forecasts**: if the user includes a [`predtimechart-config.yml`
+   file](#dashboard-ptc), then the dashboard will include a forecast
+   page.
+ - **Evaluations**: if the user includes a [`predevals-config.yml`
+   file](#dashboard-predevals-config), then the dashboard will include an
+   evaluations page.
+ - **Additional pages**: Any additional files included in `pages/` will be
+   included in the site, so long as they are also declared in the
+   `site-config.yml` file (described in detail in [Customizing the dashboard
+   website](#dashboard-customization)).
+
+For example, the [dashboard template](https://github.com/hubverse-org/hub-dashboard-template)
+contains the following files:
+
+- `site-config.yml`
+- `pages/index.qmd` --- home page
+- `pages/about.md` --- about the hub staff
+- `pages/data.qmd` --- how to access data from S3[^pages-data]
+- `pages/img/` --- images for the about page
+- `predtimechart-config.yml`
+- `predevals-config.yml`
+
+[^pages-data]: This is an optional page for cloud-enabled hubs. The user has to
+    manually add the S3 bucket name to the YAML header or delete this file if
+    it's not relevant. This would normally be a page similar to the forecast
+    and eval pages (i.e. generated optionally by the site builder). Since the
+    hub administrator may want to add additional information or rephrase some
+    elements, we left it as a boilerplate instead of attempting to try to code
+    a situation where we have a partial template and join pages together.
+
+When the site is rendered, you can see [source for the hub-dashboard-template
+website](https://github.com/hubverse-org/hub-dashboard-template/tree/gh-pages),
+shows the following files and folders.
 
 | site component | from site builder | from user | optional |
 | :-------- | :---------------- | :-------- | ------- |
@@ -55,8 +92,8 @@ For example, the [source for the hub-dashboard-template website](https://github.
 | `about.html` | --- | `pages/about.md` | yes |
 | `data.html` | --- | `pages/data.qmd` | yes |
 | `img/` | --- | `pages/img` | yes |
-| `eval.html` | `static/eval.qmd` | --- | yes |
-| `forecast.html` | `static/eval.qmd` | --- | yes |
+| `eval.html` | `static/eval.qmd` | `predevals-config.yml` | yes |
+| `forecast.html` | `static/eval.qmd` | `predtimechart-config.yml` | yes |
 | `resources/` | `static/resources/` | --- | no |
 | `site_libs` | `static/_quarto.yml` | --- | no |
 
@@ -211,3 +248,15 @@ zero, then the script returns with status code 0, otherwise, it returns with
 status code 1, which is an error.
 
 
+## References
+
+Here are links to some concepts that are used in the website builder.
+
+- [Building a website using quarto](https://quarto.org/docs/websites/)
+- [BASH scripting cheat sheet](https://devhints.io/bash)
+- `yq` [tips and tricks](https://mikefarah.gitbook.io/yq/usage/tips-and-tricks)
+  and [recipes](https://mikefarah.gitbook.io/yq/recipes). Specific operators
+  can be found in the comments of the
+  [`modify-quarto-yml.sh`](https://github.com/hubverse-org/hub-dash-site-builder/tree/main/modify-quarto-yml.sh)
+  file in the hub-dash-site-builder repository.
+- [Dockerfile reference](https://docs.docker.com/reference/dockerfile/)

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -54,7 +54,7 @@ with a link to it. However, the user has different options available to them.
    file](#dashboard-ptc), then the dashboard will include a forecast
    page.
  - **Evaluations**: if the user includes a [`predevals-config.yml`
-   file](#dashboard-predevals-config), then the dashboard will include an
+   file](#dashboard-predevals), then the dashboard will include an
    evaluations page.
  - **Additional pages**: Any additional files included in `pages/` will be
    included in the site, so long as they are also declared in the

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -64,8 +64,8 @@ with a link to it. However, the user has different options available to them.
 For example, the [dashboard template](https://github.com/hubverse-org/hub-dashboard-template)
 contains the following files:
 
-- `site-config.yml`
-- `pages/index.qmd` --- home page
+- `site-config.yml` --- (required) site configuration
+- `pages/index.qmd` --- (required) home page
 - `pages/about.md` --- about the hub staff
 - `pages/data.qmd` --- how to access data from S3[^pages-data]
 - `pages/img/` --- images for the about page

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -75,9 +75,41 @@ incomplete quarto website. The incomplete parts are:
 The site builder image effectively performs four steps to complete and render
 the site:
 
-1. Combine the contents of `pages/` and `static/` into a temporary directory, `/tmp/`.
+1. Combine the contents of `pages/` and `/static/` into a temporary directory, `/tmp/`.
 2. Update the JavaScript files to point to the correct resources.
 3. Use `yq` to merge `site-config.yml` into `/tmp/_quarto.yml`.
-4. Run `quarto render /tmp/` and copy the output to the output directory.
+4. Run `quarto render /tmp/` and copy the output to the output directory (`out/`).
+
+```{mermaid}
+:config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
+flowchart TD
+  subgraph dashboard
+    pages/contents["pages/[contents]"]
+    site-config.yml
+    out/
+  end
+  subgraph docker
+    subgraph /static/
+        /static/contents["/static/[contents]"]
+        /static/_quarto.yml["/static/_quarto.yml"]
+    end
+    yq{{"yq"}}
+    subgraph /tmp/
+        _quarto.yml["/tmp/_quarto.yml"]
+        contents["/tmp/[contents]"]
+        _site/["/tmp/_site/"]
+        quarto{{"quarto"}}
+    end
+  end
+  pages/contents --> contents
+  /static/contents --> contents
+  site-config.yml --- yq
+  /static/_quarto.yml --- yq
+  yq -->|yq -i '...' _quarto.yml | _quarto.yml
+  _quarto.yml --> quarto
+  contents --> quarto
+  quarto -->|quarto render /tmp/| _site/ --> out/
+
+```
 
 

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -15,6 +15,16 @@ was designed under the following motivations:
    should not need to handle any templating that cannot be easily automated.
 4. We should not have to maintain a server to deploy these sites.
 
+:::{admonition} Prior knowledge
+
+We strongly recommend to first read through the [Local dashboard
+workflow](./dashboard-local.md) to understand the overarching workflow.
+
+This page in particular goes into detail about the final step of the workflow,
+[Generating the site](#dashboard-local-site).
+
+:::
+
 
 ## Installation
 

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -27,7 +27,7 @@ docker pull ghcr.io/hubverse-org/hub-dash-site-builder:latest
 (dashboard-site-source)=
 ## How the website is built (a tale of two sources)
 
-The website that is built is a fully static site that can be viewed locally. It
+The website that is built is a fully static site that [can be viewed locally](./dashboard-local.md). It
 is the result of a combination of two sources:
 
 1. [dashboard website builder `static/` directory](https://github.com/hubverse-org/hub-dash-site-builder/tree/main/static) and,
@@ -199,7 +199,8 @@ The workflow that we came up with is called [build-container.yaml](https://githu
   trigger.
 
 There is a bit of a dance that's required for this job to run, which is
-described in GitHub's Publishing Docker images guide (see above for link).
+described in [GitHub's Publishing Docker images
+guide](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages).
 The reason for this dance is so we can extract metadata for the image.
 
 The important bit is the "Build and export" step, which builds the docker image
@@ -233,7 +234,7 @@ from the build image job will be redundant.
 This is similar to the build image except that instead of building the image,
 we are loading it from an artifact and pushing it to the registry.
 
-The final step of this job is to generate an artifact attestation, which is a
+The final step of this job is to generate [an artifact attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds), which is a
 way to provide a build provenance for downstream validation.
 
 

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -47,18 +47,18 @@ is the result of a combination of two sources:
 
 For example, the [source for the hub-dashboard-template website](https://github.com/hubverse-org/hub-dashboard-template/tree/gh-pages), shows the following files and folders.
 
-| site component | from site builder | from user |
-| :-------- | :---------------- | :-------- |
-| Menu Items | `static/_quarto.yml` | `site-config.yml` |
-| Theme      | `static/_quarto.yml` | `site-config.yml` |
-| `index.html` | --- | `pages/index.qmd` |
-| `about.html` | --- | `pages/about.md` |
-| `data.html` | --- | `pages/data.qmd` |
-| `img/` | --- | `pages/img` |
-| `eval.html` | `static/eval.qmd` | --- |
-| `forecast.html` | `static/eval.qmd` | --- |
-| `resources/` | `static/resources/` | --- |
-| `site_libs` | `static/_quarto.yml` | --- |
+| site component | from site builder | from user | optional |
+| :-------- | :---------------- | :-------- | ------- |
+| Menu Items | `static/_quarto.yml` | `site-config.yml` | no  |
+| Theme      | `static/_quarto.yml` | `site-config.yml` | yes |
+| `index.html` | --- | `pages/index.qmd` | no |
+| `about.html` | --- | `pages/about.md` | yes |
+| `data.html` | --- | `pages/data.qmd` | yes |
+| `img/` | --- | `pages/img` | yes |
+| `eval.html` | `static/eval.qmd` | --- | yes |
+| `forecast.html` | `static/eval.qmd` | --- | yes |
+| `resources/` | `static/resources/` | --- | no |
+| `site_libs` | `static/_quarto.yml` | --- | no |
 
 On its own, the `static/` directory of the dashboard website contains an
 incomplete quarto website. The incomplete parts are:
@@ -114,6 +114,17 @@ flowchart TD
 The entirety of these steps are performed by [the `render.sh` script](https://github.com/hubverse-org/hub-dash-site-builder/tree/main/render.sh), which exists
 in the docker container as an executable.
 
+### Optional Components
+
+Hubs do not have to have data that are compatible with the forecast
+visualization or evaluations to build a website. Case in point:
+<https://reichlab.io/variant-nowcast-hub-dashboard/>. This dashboard does not
+have the Forecast or Evals page. Instead, it has self-generated reports.
+
+If a hub does not want to build either the forecast or evaluations pages, they
+can omit the predevals or predtimechart config files. When this happens, the
+site builder will remove these pages and the associated resources before
+building the quarto site.
 
 ## How the image is built
 

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -182,7 +182,7 @@ and bundled with the site.
 
 The images is built using GitHub actions and [deployed to GitHub's container registry](https://github.com/hubverse-org/hub-dash-site-builder/pkgs/container/hub-dash-site-builder/406574245?tag=latest).
 
-We initially cribbed the build workflow from [GitHub's Publishing Docker images
+We initially created the build workflow by referencing [GitHub's Publishing Docker images
 guide](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages),
 but we also wanted to be able to test the image and only publish when we
 created a tag or release AND we wanted to be mindful of good security practices

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -60,7 +60,9 @@ For example, the [source for the hub-dashboard-template website](https://github.
 | `resources/` | `static/resources/` | --- | no |
 | `site_libs` | `static/_quarto.yml` | --- | no |
 
-On its own, the `static/` directory of the dashboard website contains an
+### An incomplete boilerplate
+
+On its own, the `static/` directory of the dashboard site builder contains an
 incomplete quarto website. The incomplete parts are:
 
 1. `index.qmd` is missing
@@ -125,6 +127,19 @@ If a hub does not want to build either the forecast or evaluations pages, they
 can omit the predevals or predtimechart config files. When this happens, the
 site builder will remove these pages and the associated resources before
 building the quarto site.
+
+## How the visualizations work
+
+If the dashboard is built independent from the data generation, how do the
+visualizations work? They work because the visualization pages each call a
+script that loads either predtimechart or predevals with a JavaScript function
+that is designed to fetch data for these modules. All of the work of fetching
+the data is done by the browser, but this does require data to exist.
+
+For public hubs, these data live on a separate branch that we can access via
+a `raw.githubusercontent.com` URL. For private hubs, data can be built locally
+and bundled with the site.
+
 
 ## How the image is built
 

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -3,4 +3,37 @@
 The [dashboard website
 builder](https://github.com/hubverse-org/hub-dash-site-builder) is a thin
 wrapper around [the quarto publishing system](https://quarto.org) and
-[yq](#dashboard-tool-yq).
+[yq](#dashboard-tool-yq). This tool was designed under the following
+motivations:
+
+1. Maintenance of this dashboard should be independent from hub maintenance.
+2. Anyone should be able to deploy a dashboard as long as they have a hub with
+   target data that they can access.
+3. Knowledge of any particular website generator is not required.
+
+## Sources and sinks
+
+The website that is built is a fully static site that can be viewed locally. It
+is the result of a combination of two sources, the
+[dashboard website builder `static/` directory](https://github.com/hubverse-org/hub-dash-site-builder/tree/main/static) and [the dashboard repository](https://github.com/hubverse-org/hub-dashboard-template/).
+
+For example, the [source for the hub-dashboard-template website](https://github.com/hubverse-org/hub-dashboard-template/tree/gh-pages), shows the following files and folders.
+
+| site component | from site builder | from user |
+| :-------- | :---------------- | :-------- |
+| Menu Items | `static/_quarto.yml` | `site-config.yml` |
+| Theme      | `static/_quarto.yml` | `site-config.yml` |
+| `index.html` | | `pages/index.qmd` |
+| `about.html` | | `pages/about.md` |
+| `data.html` | | `pages/data.qmd` |
+| `img/` | | `pages/img` |
+| `eval.html` | `static/eval.qmd` | |
+| `forecast.html` | `static/eval.qmd` | |
+| `resources/` | `static/resources/` | |
+| `site_libs` | `static/_quarto.yml` | `site-config.yml` |
+
+The site builder effectively performs three steps to render the site:
+
+1. copy the contents of `static/` into `pages/`
+2. merge `site-config.yml` into `_quarto.yml`
+3. run `quarto render`

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -1,0 +1,6 @@
+# Generating the Dashboard Website
+
+The [dashboard website
+builder](https://github.com/hubverse-org/hub-dash-site-builder) is a thin
+wrapper around [the quarto publishing system](https://quarto.org) and
+[yq](#dashboard-tool-yq).

--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -1,21 +1,49 @@
 # Generating the Dashboard Website
 
 The [dashboard website
-builder](https://github.com/hubverse-org/hub-dash-site-builder) is a thin
-wrapper around [the quarto publishing system](https://quarto.org) and
-[yq](#dashboard-tool-yq). This tool was designed under the following
-motivations:
+builder](https://github.com/hubverse-org/hub-dash-site-builder) is a [docker
+image](#dashboard-tool-docker) which is thin wrapper around [the quarto
+publishing system](#dashboard-tool-yq) and [yq](#dashboard-tool-yq). This tool
+was designed under the following motivations:
 
 1. Maintenance of this dashboard should be independent from hub maintenance.
 2. Anyone should be able to deploy a dashboard as long as they have a hub with
    target data that they can access.
-3. Knowledge of any particular website generator is not required.
+3. The only knowledge anyone should need is of Markdown, YAML, and basic
+   operation of GitHub workflows. Knowledge of any particular [website
+   generator](https://jamstack.org/generators/) is not required and the user
+   should not need to handle any templating that cannot be easily automated.
+4. We should not have to maintain a server to deploy these sites.
 
-## Sources and sinks
+## References
+
+Here are links to some concepts that are used in the website builder.
+
+- [Building a website using quarto](https://quarto.org/docs/websites/)
+- [BASH scripting cheat sheet](https://devhints.io/bash)
+- `yq` [tips and tricks](https://mikefarah.gitbook.io/yq/usage/tips-and-tricks)
+  and [recipes](https://mikefarah.gitbook.io/yq/recipes). Specific operators
+  can be found in the comments of the
+  [`modify-quarto-yml.sh`](https://github.com/hubverse-org/hub-dash-site-builder/tree/main/modify-quarto-yml.sh)
+  file in the hub-dash-site-builder repository.
+- [Dockerfile reference](https://docs.docker.com/reference/dockerfile/)
+
+## Installation
+
+You can install the latest version of this tool with docker:
+
+```bash
+docker pull ghcr.io/hubverse-org/hub-dash-site-builder:latest
+```
+
+(dashboard-site-source)=
+## How the website is built (a tale of two sources)
 
 The website that is built is a fully static site that can be viewed locally. It
-is the result of a combination of two sources, the
-[dashboard website builder `static/` directory](https://github.com/hubverse-org/hub-dash-site-builder/tree/main/static) and [the dashboard repository](https://github.com/hubverse-org/hub-dashboard-template/).
+is the result of a combination of two sources:
+
+1. [dashboard website builder `static/` directory](https://github.com/hubverse-org/hub-dash-site-builder/tree/main/static) and,
+2. [the dashboard repository](https://github.com/hubverse-org/hub-dashboard-template/)
 
 For example, the [source for the hub-dashboard-template website](https://github.com/hubverse-org/hub-dashboard-template/tree/gh-pages), shows the following files and folders.
 
@@ -23,17 +51,33 @@ For example, the [source for the hub-dashboard-template website](https://github.
 | :-------- | :---------------- | :-------- |
 | Menu Items | `static/_quarto.yml` | `site-config.yml` |
 | Theme      | `static/_quarto.yml` | `site-config.yml` |
-| `index.html` | | `pages/index.qmd` |
-| `about.html` | | `pages/about.md` |
-| `data.html` | | `pages/data.qmd` |
-| `img/` | | `pages/img` |
-| `eval.html` | `static/eval.qmd` | |
-| `forecast.html` | `static/eval.qmd` | |
-| `resources/` | `static/resources/` | |
-| `site_libs` | `static/_quarto.yml` | `site-config.yml` |
+| `index.html` | --- | `pages/index.qmd` |
+| `about.html` | --- | `pages/about.md` |
+| `data.html` | --- | `pages/data.qmd` |
+| `img/` | --- | `pages/img` |
+| `eval.html` | `static/eval.qmd` | --- |
+| `forecast.html` | `static/eval.qmd` | --- |
+| `resources/` | `static/resources/` | --- |
+| `site_libs` | `static/_quarto.yml` | --- |
 
-The site builder effectively performs three steps to render the site:
+On its own, the `static/` directory of the dashboard website contains an
+incomplete quarto website. The incomplete parts are:
 
-1. copy the contents of `static/` into `pages/`
-2. merge `site-config.yml` into `_quarto.yml`
-3. run `quarto render`
+1. `index.qmd` is missing
+2. The JavaScript in `resources/` is incomplete. There is a single line that
+   defines the root folder for resource access, with a placeholder called
+   `{ROOT}`, which needs to be replaced by a local folder or URL for the
+   resource:
+   ```js
+   const root = "{ROOT}";
+   ```
+
+The site builder image effectively performs four steps to complete and render
+the site:
+
+1. Combine the contents of `pages/` and `static/` into a temporary directory, `/tmp/`.
+2. Update the JavaScript files to point to the correct resources.
+3. Use `yq` to merge `site-config.yml` into `/tmp/_quarto.yml`.
+4. Run `quarto render /tmp/` and copy the output to the output directory.
+
+

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -125,6 +125,7 @@ developer/security.md
 developer/cloud-onboarding.md
 developer/dashboard-tools.md
 developer/dashboard-local.md
+developer/dashboard-site.md
 ```
 
 ```{toctree}


### PR DESCRIPTION
This adds documentation for the dashboard site: what it does, its architecture, how it's built, and how it's tested. 


Preview: https://hubdocs--326.org.readthedocs.build/en/326/developer/dashboard-site.html