### PR TITLE
fix copy paste typo

### DIFF
--- a/docs/source/developer/dashboard-site.md
+++ b/docs/source/developer/dashboard-site.md
@@ -264,7 +264,10 @@ from the build image job will be redundant.
 ### Publish
 
 - **purpose**: publish the built docker image
-- **permissions**: read-all
+- **permissions**:
+  - contents: read (cannot write to the repository contents)
+  - packages: write (can create a docker image on ghcr.io)
+  - attestations: write (see below)
 - **runs on**: push of a tag that starts with "v" and a workflow dispatch from
   main where "publish" is selected
 


### PR DESCRIPTION
There was a copy paste typo in the build process for the site builder WRT to permissions, so I fixed it