### PR TITLE
instructions for dashboard staging

### DIFF
--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -1,0 +1,148 @@
+# Staging dashboard changes
+
+This chapter deals with what to do when you are staging changes to the
+dashboard. This incorporates elements from the [local dashboard
+workflow](./dashboard-local.md) and the [operational
+workflows](./dashboard-workflows.md), so it is _very important_ to be familiar
+with these resources before reading on.
+
+When staging dashboard changes, it is helpful to think about how the data flow
+from the source to the branches, which is illustrated by the simplified diagram
+below[^hub-source].
+
+[^hub-source]: This graph is simplified in the following ways: 1. in reality,
+    the inputs flow directly into the generate workflows. 2. data from the hub
+    is explicitly used in the `generate-data.yaml` workflow from the control
+    room, the hub is defined in `site-config.yml`
+
+```{mermaid}
+:config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
+flowchart TD
+    subgraph dashboard
+        contents[/"[site contents]"/]
+        site-config.yaml[/site-config.yml/]
+        predtimechart-config.yaml[/predtimechart-config.yml/]
+        predevals-config.yaml[/predevals-config.yml/]
+        build-data.yaml
+        build-site.yaml
+    end
+    subgraph control-room
+        generate-site.yaml
+        generate-data.yaml
+    end
+    subgraph artifacts
+        site[\site\]
+        eval-data[\eval-data\]
+        forecast-data[\forecast-data\]
+    end
+    subgraph dashboard-branches
+        gh-pages>gh-pages]
+        predevals/data>predevals/data]
+        ptc/data>ptc/data]
+    end
+    contents --> build-site.yaml
+    site-config.yaml --> build-site.yaml
+    site-config.yaml --> build-data.yaml
+    predevals-config.yaml --> build-data.yaml
+    predtimechart-config.yaml --> build-data.yaml
+    build-site.yaml --> generate-site.yaml --> artifacts
+    build-data.yaml --> generate-data.yaml --> artifacts
+    artifacts --> push-things.yaml --> dashboard-branches
+```
+
+I've arrange the diagram starting with the configuration files because in order
+to know what pieces are affected by modification of a given tool, you should
+start with the config file and follow the arrows.
+
+| tool | configuration file | workflow | artifact | branch |
+| :--- | :----------------- | :------- | :------- | :----- |
+| hub-dash-site-builder | `site-config.yml` | `generate-site.yaml` | site | gh-pages |
+| hubPredEvalsData-docker | `predevals-config.yml` | `generate-data.yaml` | eval-data | predevals/data |
+| hub-dashboard-predtimechart | `predtimechart-config.yml` | `generate-data.yaml` | forecast-data | ptc/data |
+
+## What does it mean to stage changes?
+
+The concept of staging changes is the same as a dress rehearsal for a play. You
+get all the players together and execute the performance exactly as you would if
+an audience were there. You are confirming everything is operating as expected
+and providing room for improvements if things go awry.
+
+Similarly, since the dashboard is automatically deployed to any repository that
+uses it, it is important to confirm that changes to any components produce
+expected results and do not break the dashboards in production. To confirm
+this, it is important to create a branch in the control room that implements
+the changes and temporary dashboard website to preview. This website should
+adhere to these three descriptors:
+
+1. its workflows should point to an in-development branch of the control room
+2. it should implement any configuration file changes if necessary
+3. it should be relatively quick to test
+
+Once that is set up, you can let the website build and confirm that you are
+seeing the output you expect and confirm that you are not seeing any unexpected
+artifacts or behavior.
+
+## When to stage changes
+
+You will need to stage changes when any of the tools produces results whose
+structures diverge significantly from the output of the latest versions of the
+dashboard tools. The judgement of what a significant divergence is can be
+subjective, but a pretty clear checklist to consult is:
+
+ 1. Is there a new option that is available from the configuration file?
+ 1. Does the tool generate new files?
+ 1. Is a previously required option becoming optional?
+ 1. Are the arguments for the reusable workflows changing?
+ 1. Is a previously optional option becoming required? _(breaking)_
+ 1. Is the structure of the generated files changing? _(breaking)_
+
+**If the answer to any of the above questions is yes, then you need to stage
+changes before pushing a release.**
+
+:::{admonition} Not all changes need to be staged
+:class: note
+
+You might be able to think of situations that were not mentioned above. For
+example, addressing a bug fix for something that can easily be verified with
+internal tests does not absolutely need to fully stage changes for deployment.
+
+Another situation is if the arguments for the underlying tools change, but
+nothing about the input or output data change. Because everything is
+encapsulated in the GitHub workflows, it is sufficient to test the workflows
+using the GitHub app to confirm it works.
+
+Sometimes a fix is urgent enough that you need to deploy without running through
+the staging. It's okay to do this if the change is small enough, but for large
+changes, you must stage the changes and verify that it works.
+
+:::
+
+## Elements you can inspect
+
+There are two methods to verify that your changes are having the effect you want,
+inspecting the artifacts and previewing the website.
+
+### Inspecting the artifacts
+
+This method is the least invasive because you can run the workflows as a "dry
+run" and then download the github artifacts to make sure they look the way they
+should. If no configuration files need to change, this can be done directly from
+the control room with the hubDashboard GitHub app.
+
+If it's data that are changing, you can even use the artifacts to preview the
+website locally.
+
+### Previewing the website on a fork
+
+There are some situations where you want to preview the website on a fork of a
+dashboard. You might want to do this if you have a breaking change and you need
+to modify a config file. This is more involved.
+
+## Performing the staging
+
+In order to stage changes, you need to identify what needs to be modified.
+
+## Using the app to generate artifacts
+
+## Using a fork of a dashboard
+

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -39,7 +39,7 @@ branches of the repository. In order to do that, they use the following steps:
 1. install the tool that's required
 2. download the dashboard configuration file
 3. download the additional resources needed
-4. run a the command to generate output
+4. run the command to generate output
 5. push that output to a branch
 
 When thinking about staging the changes
@@ -56,7 +56,7 @@ For example in building the forecast data, the steps are:
 
 similarly, for building the site, the steps are:
 
-1. enter the [hub-dash-site-builder](https://github.com/hubverse-org/hub-dash-site-builder)
+1. launch an interactive shell from the [hub-dash-site-builder](https://github.com/hubverse-org/hub-dash-site-builder)
 2. download `site-config.yml` from the dashboard repo
 3. download the dashboard repo contents
 4. run `render.sh`
@@ -127,7 +127,7 @@ flowchart TD
     artifacts -.-> push-things.yaml ==> dashboard-branches
 ```
 
-I've arrange the diagram starting with the configuration files because **in order
+I've arranged the diagram starting with the configuration files because **in order
 to know what pieces are affected by modification of a given tool, you should
 start with the config file** and follow the arrows.
 
@@ -268,13 +268,13 @@ In order to test this, we needed to do the following
 3. create a fork of a dashboard that would point to this new branch in the control room
 
 
-After merging [the updated dockerfile with new tests and interface](https://github.com/hubverse-org/hub-dash-site-builder/pull/21) into the main branch of the repository, I created the docker image from the main branchby using the [Create, Test, and Publish Docker Image workflow](https://github.com/hubverse-org/hub-dash-site-builder/actions/workflows/build-container.yaml). Note that this docker image has the `main` tag[^image-name], but it is not published.
+After merging [the updated dockerfile with new tests and interface](https://github.com/hubverse-org/hub-dash-site-builder/pull/21) into the main branch of the repository, I created the docker image from the main branch by using the [Create, Test, and Publish Docker Image workflow](https://github.com/hubverse-org/hub-dash-site-builder/actions/workflows/build-container.yaml). Note that this docker image has the `main` tag[^image-name], but it is not published.
 
 [^image-name]: This was before we had fully ironed out the details of the docker publishing workflow, so the image tag is actually `znk-dispatch-fix-34`. I am writing this as if we had the workflow that we have now.
 
 Once I did that, I opened [hubverse-org/hub-dashboard-control-room#59](https://github.com/hubverse-org/hub-dashboard-control-room/pull/59) and then modified the workflow to use the new container and the new interface (see [hubverse-org/hub-dashboard-control-room@58628f0f4](https://github.com/hubverse-org/hub-dashboard-control-room/pull/59/commits/58628f0f4cef7e5c2cb5dc9455dc63235f47ec1d)).
 
-I think created a fork of the dashboard repositories and changed their `build-site.yaml` workflows to use the branch I was testing[^testing-branch]
+I created a fork of the dashboard repositories and changed their `build-site.yaml` workflows to use the branch I was testing[^testing-branch]
 
 [^testing-branch]: In this process, I actually modified the workflow for the
     app, ran it without pushing, and inspected the artifacts. This had the same

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -42,7 +42,14 @@ branches of the repository. In order to do that, they use the following steps:
 4. run the command to generate output
 5. push that output to a branch
 
-When thinking about staging the changes
+When thinking about staging the changes, it is important to remember that there
+is not a one-size-fits-all process for this. You have to think holistically and
+look at the changes you want to make from the perspective of a hub administrator
+who just wants a dashboard for their hub that they don't have to futz with too
+much. From that perspective, it does not really matter how elegant the tools are
+as long as the workflows can run them. What matters is that the users have
+sensible defaults and options they can add or omit from their configuration
+files.
 
 :::{admonition} Examples
 

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -419,8 +419,8 @@ Once I did that, I opened [hubverse-org/hub-dashboard-control-room#59](https://g
 
 I created a fork of the dashboard repositories and changed their `build-site.yaml` workflows to use the branch I was testing[^testing-branch]
 
-[^testing-branch]: In this process, I actually modified the workflow for the
-    app, ran it without pushing, and inspected the artifacts. This had the same
+[^testing-branch]: In this process, I did not create any forks. Instead, I [modified the workflow for the
+    app](https://github.com/hubverse-org/hub-dashboard-control-room/pull/59/commits/12c41a279fdcf70a8dde9878367edbc22690ae3b), ran it without pushing, and inspected the artifacts. This had the same
     effect, but meant that I could test several repositories at once.
 
 ```diff
@@ -429,6 +429,46 @@ I created a fork of the dashboard repositories and changed their `build-site.yam
 ```
 
 I then ran the workflows from the dashboard forks to confirm that the site was correctly generated.
+
+:::
+
+:::{admonition} Staging without forks with the GitHub App
+:class: note
+:name: dashboard-staging-app
+
+One tool that can help with staging is
+[hubDashboard](https://github.com/apps/hubDashboard). It was originally
+designed so that hub administrators could have a dashboard website without
+needing to maintain GitHub workflows. We no longer use it for this purpose.
+
+The app does two things:
+
+1. any repository owner can "install" the app on their repository, giving it
+   permissions to read and write repository contents
+2. we can authenticate as the app in the control room, and use it to generate a
+   temporary github PAT that will give us permissions to push to a repository
+   that has the app installed. We control a list of [known hubs](https://github.com/hubverse-org/hub-dashboard-control-room/blob/main/known-hubs.json) that have the app installed.
+
+Because of this, we have the following pattern:
+
+```{mermaid}
+:config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
+flowchart TD
+    subgraph repo-flow
+        subgraph dashboard
+            d[dashboard workflows]
+            s[dashboard-site]
+            t[token]
+        end
+        d[dashboard] -->|uses| c[control-room] -->|builds to| s
+        d[dashboard] -->|generates|t -->|used by| c
+    end
+    subgraph app-flow
+        app -->|installed on| dashboard
+        app -->|generates|token-->|used by| c
+        c -->|builds to| s
+    end
+```
 
 :::
 

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -111,6 +111,30 @@ that the following sequence will need to be followed:
    changes, you will need to preview the site locally)
 6. add the new option and repeat steps 4 and 5
 
+The reason why these JavaScript tools can be staged locally is because they are
+loaded when someone visits the site.
+
+```{mermaid}
+:config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
+flowchart TD
+    subgraph site
+        forecast.html
+        eval.html
+        subgraph resources
+            predtimechart.js
+            predevals_interface.js
+        end
+    end
+    hub-dash-site-builder -..->|render.sh| site
+    forecast.html -->|calls| predtimechart.js -->|loads| predtimechart["reichlab/predtimechart@v3"]
+    predtimechart.js -->|fetches| ptc/data[(ptc/data)]
+    predtimechart.js -->|updates| forecast.html
+    eval.html -->|calls| predevals_interface.js -->|loads| predevals["hubverse-org/predevals@v1"]
+    predevals_interface.js -->|fetches| predevals/data[(predevals/data)]
+    predevals_interface.js -->|updates| eval.html
+```
+
+
 ## Broad steps for staging changes
 
 The process for staging changes looks a bit different depending on where you are

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -10,10 +10,14 @@ When staging dashboard changes, it is helpful to think about how the data flow
 from the source to the branches, which is illustrated by the simplified diagram
 below[^hub-source].
 
-[^hub-source]: This graph is simplified in the following ways: 1. in reality,
-    the inputs flow directly into the generate workflows. 2. data from the hub
-    is explicitly used in the `generate-data.yaml` workflow from the control
-    room, the hub is defined in `site-config.yml`
+[^hub-source]: This graph is simplified in the following ways: 1. The local
+    dashboard workflows, which call the control-room workflows are excluded from
+    this diagram because they act as a messenger, passing data downstream. 2.
+    data from the hub is explicitly used in the `generate-data.yaml` workflow
+    from the control room, the hub is defined in `site-config.yml`. 3. The
+    artifacts and branches generated from the workflows are performed in
+    parallel; generate-site.yaml generates the `site` and `gh-pages` artifact
+    and branch while generate-data.yaml generates the rest.
 
 ```{mermaid}
 :config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
@@ -23,8 +27,6 @@ flowchart TD
         site-config.yaml[/site-config.yml/]
         predtimechart-config.yaml[/predtimechart-config.yml/]
         predevals-config.yaml[/predevals-config.yml/]
-        build-data.yaml
-        build-site.yaml
     end
     subgraph control-room
         generate-site.yaml
@@ -40,13 +42,13 @@ flowchart TD
         predevals/data>predevals/data]
         ptc/data>ptc/data]
     end
-    contents --> build-site.yaml
-    site-config.yaml --> build-site.yaml
-    site-config.yaml --> build-data.yaml
-    predevals-config.yaml --> build-data.yaml
-    predtimechart-config.yaml --> build-data.yaml
-    build-site.yaml --> generate-site.yaml --> artifacts
-    build-data.yaml --> generate-data.yaml --> artifacts
+    contents --> generate-site.yaml
+    site-config.yaml --> generate-site.yaml
+    site-config.yaml --> generate-data.yaml
+    predevals-config.yaml --> generate-data.yaml
+    predtimechart-config.yaml --> generate-data.yaml
+    generate-site.yaml --> artifacts
+    generate-data.yaml --> artifacts
     artifacts --> push-things.yaml --> dashboard-branches
 ```
 

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -199,7 +199,49 @@ flowchart TD
 
 ```
 
-For example in late March 2025, we wanted to update the site builder to [v1.0.0](https://github.com/hubverse-org/hub-dash-site-builder/releases/tag/v1.0.0).
+
+:::{admonition} Example
+
+For example in late March 2025, we wanted to update the site builder to [v1.0.0](https://github.com/hubverse-org/hub-dash-site-builder/releases/tag/v1.0.0). This changed the interface so
+instead of positional BASH arguments, we used argument flags:
+
+```{code-block} bash
+:caption: before, positional arguments
+bash /render.sh "$OWNER" "$REPO" "ptc/data" "" "$HAS_FORECASTS"
+```
+
+```{code-block} bash
+:caption: after, named arguments
+render.sh -u "$OWNER" -r "$REPO"
+```
+
+In order to test this, we needed to do the following
+
+1. build the image from the main branch
+2. create a branch in the control room that would reference this image and modify the commands
+3. create a fork of a dashboard that would point to this new branch in the control room
+
+
+After merging [the updated dockerfile with new tests and interface](https://github.com/hubverse-org/hub-dash-site-builder/pull/21) into the main branch of the repository, I created the docker image from the main branchby using the [Create, Test, and Publish Docker Image workflow](https://github.com/hubverse-org/hub-dash-site-builder/actions/workflows/build-container.yaml). Note that this docker image has the `main` tag[^image-name], but it is not published.
+
+[^image-name]: This was before we had fully ironed out the details of the docker publishing workflow, so the image tag is actually `znk-dispatch-fix-34`. I am writing this as if we had the workflow that we have now.
+
+Once I did that, I opened [hubverse-org/hub-dashboard-control-room#59](https://github.com/hubverse-org/hub-dashboard-control-room/pull/59) and then modified the workflow to use the new container and the new interface (see [hubverse-org/hub-dashboard-control-room@58628f0f4](https://github.com/hubverse-org/hub-dashboard-control-room/pull/59/commits/58628f0f4cef7e5c2cb5dc9455dc63235f47ec1d)).
+
+I think created a fork of the dashboard repositories and changed their `build-site.yaml` workflows to use the branch I was testing[^testing-branch]
+
+[^testing-branch]: In this process, I actually modified the workflow for the
+    app, ran it without pushing, and inspected the artifacts. This had the same
+    effect, but meant that I could test several repositories at once.
+
+```diff
+-uses: hubverse-org/hubverse-org/hub-dashboard-control-room/.github/workflows/generate-site.yaml@main
++uses: hubverse-org/hubverse-org/hub-dashboard-control-room/.github/workflows/generate-site.yaml@znk/use-release-hsdb/58
+```
+
+I then ran the workflows from the dashboard forks to confirm that the site was correctly generated.
+
+:::
 
 
 

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -13,6 +13,11 @@ that the changes are expected to work.
 
 :::
 
+:::{contents} Table of Contents
+:depth: 4
+:backlinks: none
+:::
+
 ## Introduction
 
 Any change to a dashboard component that adds a new feature should be staged

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -456,11 +456,37 @@ workflows_](https://github.com/hubverse-org/hub-dashboard-control-room/blob/9b2e
 The only difference is that there is a job that will fetch repositories that
 has the app installed.
 
-The reason this works because the control room stores two secrets: the App ID `${{
-vars.APP_ID }}` and a private key `${{ secrets.PRIVATE KEY }}` (similar to your
+The reason this works because the control room stores two secrets: the App ID (`${{
+vars.APP_ID }}`) and a private key (`${{ secrets.PRIVATE KEY }}`) (similar to your
 SSH private key). These two items are passed as `secrets` to the reusable
 workflows and allows the control room workflows to authenticate as the app,
 which can generate a temporary PAT for any repository that installed it.
+
+```{mermaid}
+:config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
+flowchart TD
+    subgraph dashboard-workflow
+        db["dashboard repository"]
+        t["key: GITHUB_TOKEN"]
+        id["id: 'none'"]
+        c["reusable workflow"]
+        site
+        db --> t --> c
+        id --> c
+        c -->|token from GITHUB_TOKEN| site
+    end
+    subgraph app-workflow
+        adb["dashboard repository"]
+        app{app}
+        pk["key: PRIVATE_KEY"]
+        aid["id: APP_ID"]
+        ac["reusable workflow"]
+        asite["site"]
+        adb -->|installed| app
+        app --> pk --> ac
+        app --> aid --> ac -->|token generated from app| asite
+    end
+```
 
 The App was originally intended to be a way for dashboards to be built without
 requiring hub admins to worry about an extra workflow. Since we migrated to

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -1,18 +1,5 @@
 # Staging dashboard changes
 
-## Introduction
-
-Any change to a dashboard component that adds a new feature should be staged
-before release; that is, you should test the changes on a copy of a dashboard
-and confirm the results are what you expected AND that nothing adverse happens
-for dashboards that opt out of new features.
-
-This is not an exact science and you should use your best judgement when moving
-changes into production. The dashboards do have a lot of moving pieces, but
-they are not infinite and not insurmountable. This chapter should give you a few
-scenarios you can use to piece together the process for confidently adding new
-features or fixing critical bugs in the dashboard workflow.
-
 :::{important}
 
 This chapter deals with what to do when you are staging changes to the
@@ -26,9 +13,61 @@ that the changes are expected to work.
 
 :::
 
+## Introduction
+
+Any change to a dashboard component that adds a new feature should be staged
+before release; that is, you should test the changes on a copy of a dashboard
+and confirm the results are what you expected AND that nothing adverse happens
+for dashboards that opt out of new features.
+
+**This is not an exact science and you should use your best judgement when
+moving changes into production.** The dashboards do have a lot of moving
+pieces, but they are not infinite and not insurmountable. This chapter should
+give you a few scenarios you can use to piece together the process for
+confidently adding new features or fixing critical bugs in the dashboard
+workflow.
+
+### Generic steps of the workflow
+
+An important concept to understand is that [the control
+room](https://github.com/hubverse-org/hub-dashboard-control-room) workflows are
+just that: workflows. They implement the [local dashboard
+workflow](./dashboard-workflow.md) and **push the individual outputs to
+branches of the repository.** In order to do that, they use the following steps:
+
+1. install the tool that's required
+2. download the dashboard configuration file
+3. download the additional resources needed
+4. run a the command to generate output
+5. push that output to a branch
+
+:::{admonition} Examples
+
+For example in building the forecast data, the steps are:
+
+1. install [hub-dashboard-predtimechart](https://github.com/hubverse-org/hub-dashboard-predtimechart)
+2. download `predtimechart-config.yml` and `site-config.yml` from the dashboard repo
+3. download the hub (defined in `site-config.yml`)
+4. run `ptc_generate_target_json_files` and `ptc_generate_json_files`
+5. save the output in the `ptc/data` branch and push it
+
+similarly, for building the site, the steps are:
+
+1. enter the [hub-dash-site-builder](https://github.com/hubverse-org/hub-dash-site-builder)
+2. download `site-config.yml` from the dashboard repo
+3. download the dashboard repo contents
+4. run `render.sh`
+5. save the output in the `gh-pages` branch and push it
+
+:::
+
+
+### Data flow
+
 When staging dashboard changes, it is helpful to think about how the data flow
-from the source to the branches, which is illustrated by the diagram
-below[^hub-source].
+from the source to the branches in [the control
+room](https://github.com/hubverse-org/hub-dashboard-control-room), which is
+illustrated by the diagram below[^hub-source].
 
 [^hub-source]: This graph is simplified in the following ways: 1. The local
     dashboard workflows, which call the control-room workflows are excluded from
@@ -143,7 +182,8 @@ staging is:
 6. inspect the page and make sure that the page behaves as you expect.
 
 The reason why these JavaScript tools can be staged locally is because they are
-loaded when someone visits the site.
+loaded when someone visits the site. The site builder does not know anything
+about the underlying JavaScript.
 
 ```{mermaid}
 :config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -108,31 +108,8 @@ that the following sequence will need to be followed:
    branch
 4. generate the data
 5. generate the site and preview (NOTE: If the JavaScript component also
-   changes, you will need to preview the site locally)
+   changes, you will need to [preview the site locally](#staging-javascript))
 6. add the new option and repeat steps 4 and 5
-
-The reason why these JavaScript tools can be staged locally is because they are
-loaded when someone visits the site.
-
-```{mermaid}
-:config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
-flowchart TD
-    subgraph site
-        forecast.html
-        eval.html
-        subgraph resources
-            predtimechart.js
-            predevals_interface.js
-        end
-    end
-    hub-dash-site-builder -..->|render.sh| site
-    forecast.html -->|calls| predtimechart.js -->|loads| predtimechart["reichlab/predtimechart@v3"]
-    predtimechart.js -->|fetches| ptc/data[(ptc/data)]
-    predtimechart.js -->|updates| forecast.html
-    eval.html -->|calls| predevals_interface.js -->|loads| predevals["hubverse-org/predevals@v1"]
-    predevals_interface.js -->|fetches| predevals/data[(predevals/data)]
-    predevals_interface.js -->|updates| eval.html
-```
 
 
 ## Broad steps for staging changes
@@ -164,6 +141,30 @@ staging is:
 5. in the root of the folder, run `python -m http.server 8080` and open a
    browser to <http://localhost:8080>
 6. inspect the page and make sure that the page behaves as you expect.
+
+The reason why these JavaScript tools can be staged locally is because they are
+loaded when someone visits the site.
+
+```{mermaid}
+:config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
+flowchart TD
+    subgraph site
+        forecast.html
+        eval.html
+        subgraph resources
+            predtimechart.js
+            predevals_interface.js
+        end
+    end
+    hub-dash-site-builder -..->|render.sh| site
+    forecast.html -->|calls| predtimechart.js -->|loads| predtimechart["reichlab/predtimechart@v3"]
+    predtimechart.js -->|fetches| ptc/data[(ptc/data)]
+    predtimechart.js -->|updates| forecast.html
+    eval.html -->|calls| predevals_interface.js -->|loads| predevals["hubverse-org/predevals@v1"]
+    predevals_interface.js -->|fetches| predevals/data[(predevals/data)]
+    predevals_interface.js -->|updates| eval.html
+```
+
 
 (staging-control-room)=
 ### In the control room

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -120,9 +120,9 @@ what you are changing.
 (staging-javascript)=
 ### In JavaScript tools
 
-The JavaScript tools [PredTimeChart](https://github.com/reichlab/predtimechart)
+**The JavaScript tools [PredTimeChart](https://github.com/reichlab/predtimechart)
 and [PredEvals](https://github.com/hubverse-org/predevals) are both tools that
-can be staged locally. For either of the tools, the steps to perform local
+can be staged locally.** For either of the tools, the steps to perform local
 staging is:
 
 1. create a new branch to implement the change

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -344,6 +344,40 @@ flowchart TD
     predevals_interface.js -->|updates| eval.html
 ```
 
+:::{admonition} Purge the cache on release of JavaScript modules
+:class: important
+
+
+The JavaScript components we provide to the webpage are known as _version
+aliased_ URLs, which is signified by the `@v3` for PredTimeChart or `@v1` for
+PredEvals. This means that the sites will always get the latest version up to
+that major version number. For example, if we release version 1.1.0 of PredEvals,
+then the users downstream will have that version delivered via the CDN, but if
+we turn around and release version 2.0.0, they will still get the 1.1.0 version.
+
+When you release a JavaScript module, <https://cdn.jsDeliver.com> will pick it
+up within 12 hours, but user machines can keep it cached for up to seven days.
+
+If you want your changes to show up near instantly, you can [purge jsDeliver's CDN cache](https://www.jsdelivr.com/tools/purge) by entering two URLs.
+
+The way to do this is to **paste the URLs in the browser and replace `cdn` with `purge`**.
+Note that you also need to do this for **the un-versioned URL** as well:
+
+```{code-block}
+:caption: URLs to clear the cache for PredTimeChart: copy and paste into your browser
+https://purge.jsdelivr.net/gh/reichlab/predtimechart@v3/dist/predtimechart.bundle.js
+https://purge.jsdelivr.net/gh/reichlab/predtimechart/dist/predtimechart.bundle.js
+```
+
+```{code-block}
+:caption: URLs to clear the cache for PredEvals: copy and paste into your browser
+https://purge.jsdelivr.net/gh/hubverse-org/predevals@v1/dist/predevals.bundle.js
+https://purge.jsdelivr.net/gh/hubverse-org/predevals/dist/predevals.bundle.js
+```
+
+:::
+
+
 ### Fetching orphan branches
 
 The data generation workflows may take into account data that have already been

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -519,10 +519,27 @@ There are three situations that you will find yourself staging,
 (staging-control-room-generate)=
 ##### Control room `generate-` workflows
 
+```{mermaid}
+:config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
+flowchart LR
+    subgraph dashboard
+        build-data.yaml
+        build-site.yaml
+    end
+    subgraph control-room
+        generate-data.yaml
+        generate-site.yaml
+    end
+    build-data.yaml --> generate-data.yaml
+    build-site.yaml --> generate-site.yaml
+```
+
+
 If you are modifying one of the `generate-data.yaml` or `generate-site.yaml`
 workflows in the control room, then:
+
 1. create a branch in the control room
-2. make the changes you need to change
+2. make the changes you need to change (e.g. pointing to the correct branch of the tool you are modifying, updating the call syntax, or updating a step)
 3. (**in a fork of a dashboard repository**), change the
    `@main` tag for the reusable workflow to `@<branch-name>`
    ```diff
@@ -534,9 +551,31 @@ workflows in the control room, then:
 (staging-control-room-push)=
 ##### Control room `push-things.yaml` workflow
 
-This builds off of the [the control room generate workflows](#staging-control-room-generate).
+```{mermaid}
+:config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
+flowchart LR
+    subgraph dashboard
+        build-data.yaml
+        build-site.yaml
+    end
+    subgraph control-room
+        generate-data.yaml
+        generate-site.yaml
+        artifacts
+        push-things.yaml
+    end
+    build-data.yaml --> generate-data.yaml --> artifacts
+    build-site.yaml --> generate-site.yaml --> artifacts
+    artifacts --> push-things.yaml
+```
+
+The push things workflow is a reusable workflow that is called by other
+workflows and takes the generated artifacts and pushes them to a specific branch.
+The process for staging builds off of the [the control room generate workflows](#staging-control-room-generate) with one more step where you need to make sure the branch of the reusable
+workflow is correct.
+
 1. create a branch in the control room
-2. make the changes you need to change
+2. make the changes you need to change (e.g. pointing to the correct branch of the tool you are modifying, updating the call syntax, or updating a step)
 4. (**in the control room**) In the `generate-*` workflows, change the `push-things.yaml` workflows to use `@<branch-name>`:
    ```diff
    -uses: hubverse-org/[...]/workflows/push-things.yaml@main
@@ -553,9 +592,29 @@ This builds off of the [the control room generate workflows](#staging-control-ro
 (staging-control-room-scripts)=
 ##### Control room scripts
 
+```{mermaid}
+:config: {"theme": "base", "themeVariables": {"primaryColor": "#dbeefb", "primaryBorderColor": "#3c88be"}}
+flowchart LR
+    subgraph dashboard
+        build-data.yaml
+        build-site.yaml
+    end
+    subgraph control-room
+        generate-data.yaml
+        generate-site.yaml
+        artifacts
+        push-things.yaml
+        scripts/
+    end
+    build-data.yaml --> generate-data.yaml --> artifacts
+    build-site.yaml --> generate-site.yaml --> artifacts
+    artifacts --> push-things.yaml
+    scripts/ --> push-things.yaml
+```
+
 If a script changes, it builds off of the [the control room `push-things.yaml` workflow](#staging-control-room-push):
 1. create a branch in the control room
-2. make the changes you need to change
+2. make the changes you need to change (e.g. pointing to the correct branch of the tool you are modifying, updating the call syntax, or updating a step)
 4. (**in the control room**) In the `generate-*` workflows, change the `push-things.yaml` workflows to use `@<branch-name>`:
    ```diff
    -uses: hubverse-org/[...]/workflows/push-things.yaml@main
@@ -601,7 +660,7 @@ To stage changes to the hub-dashboard-predtimechart from the control room:
    branch
 4. generate the data
 5. generate the site and preview (NOTE: If the JavaScript component also
-   changes, you will need to preview the site locally)
+   changes, you will need to [preview the site locally](#staging-javascript))
 6. add the new option and repeat steps 4 and 5
 
 If you do not need to change any options in the control room, then you can
@@ -641,7 +700,7 @@ To stage changes to hubPredEvalsData-docker from the control room:
    branch
 4. generate the data
 5. generate the site and preview (NOTE: If the JavaScript component also
-   changes, you will need to preview the site locally)
+   changes, you will need to [preview the site locally](#staging-javascript))
 6. add the new option and repeat steps 4 and 5
 
 If you do not need to change any options in the control room, then you can
@@ -682,7 +741,7 @@ To stage changes to hub-dash-site-bulder from the control room:
    branch
 4. (optional) generate the data
 5. generate the site and preview (NOTE: If the JavaScript component also
-   changes, you will need to preview the site locally)
+   changes, you will need to [preview the site locally](#staging-javascript))
 6. add the new option and repeat step 5
 
 If you do not need to change any options in the control room, then you can

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -292,7 +292,7 @@ I then ran the workflows from the dashboard forks to confirm that the site was c
 ## Local Staging strategies
 
 The following sections will cover local staging strategies based on what
-component you are modifying working. Note that you will often have to mix
+component you are modifying. Note that you will often have to mix
 testing strategies. Please read [Where to stage
 changes](#dashboard-staging-where) for an overview.
 

--- a/docs/source/developer/dashboard-staging.md
+++ b/docs/source/developer/dashboard-staging.md
@@ -45,7 +45,7 @@ branches of the repository. In order to do that, they use the following steps:
 When thinking about staging the changes, it is important to remember that there
 is not a one-size-fits-all process for this. You have to think holistically and
 look at the changes you want to make from the perspective of a hub administrator
-who just wants a dashboard for their hub that they don't have to futz with too
+who just wants a dashboard for their hub that they don’t have to keep fixing or adjusting
 much. From that perspective, it does not really matter how elegant the tools are
 as long as the workflows can run them. What matters is that the users have
 sensible defaults and options they can add or omit from their configuration
@@ -63,7 +63,7 @@ For example in building the forecast data, the steps are:
 
 similarly, for building the site, the steps are:
 
-1. launch an interactive shell from the [hub-dash-site-builder](https://github.com/hubverse-org/hub-dash-site-builder)
+1. launch an interactive shell in a container based on  the [hub-dash-site-builder](https://github.com/hubverse-org/hub-dash-site-builder) Docker image.
 2. download `site-config.yml` from the dashboard repo
 3. download the dashboard repo contents
 4. run `render.sh`
@@ -186,7 +186,7 @@ about _how_ the resource is built or provisioned, then you can do local staging.
 ### Option 1: local staging
 
 This option is ideal for **changes that do not affect _how_ the resource is
-built or provisioned.** Doing remote staging involves the same steps as the
+built or provisioned.** Doing local staging involves the same steps as the
 [local workflow](./dashboard-local.md) except that you would install the development version of the tool
 you are testing.
 
@@ -198,7 +198,7 @@ follow this process:
 1. implement change in new branch of
    [hub-dashboard-predtimechart](https://github.com/hubverse-org/hub-dashboard-predtimechart)
    and install locally.
-2. create a local copy of a dashboard repository
+2. create a local copy of a dashboard repository and the hub it points to
 3. [generate the forecasts data](#dashboard-local-forecasts) with the
    appropriate command
 4. inspect the output (check that no files are missing or added)
@@ -356,7 +356,7 @@ flowchart TD
 
 
 The JavaScript components we provide to the webpage are known as _version
-aliased_ URLs, which is signified by the `@v3` for PredTimeChart or `@v1` for
+aliased_ URLs, which, at the time of writing, is signified by the `@v3` for PredTimeChart or `@v1` for
 PredEvals. This means that the sites will always get the latest version up to
 that major version number. For example, if we release version 1.1.0 of PredEvals,
 then the users downstream will have that version delivered via the CDN, but if
@@ -385,7 +385,7 @@ https://purge.jsdelivr.net/gh/hubverse-org/predevals/dist/predevals.bundle.js
 :::
 
 
-### Fetching orphan branches
+### Accessing pre-built data
 
 The data generation workflows may take into account data that have already been
 generated in order to save computational time. When you are staging locally, it
@@ -399,7 +399,7 @@ use in the [site builder
 tests](https://github.com/hubverse-org/hub-dash-site-builder/blob/77f40021cfb473cbcf2c9986b6aa518af13d863d/tests/run.sh#L94-L95).
 
 
-The pattern for to add a git worktree is:
+The pattern to add a git worktree is:
 
 ```bash
 git worktree add --checkout <directory> <branch>

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,6 +1,6 @@
 # The hubverse: open tools for collaborative modeling
 
-```{admonition} 📣 We have a new landing page! 
+```{admonition} 📣 We have a new landing page!
 :class: warning
 
 We have a new landing page at <https://hubverse.io/> that provides a general overview of The Hubverse. Over the next few weeks, we will be removing duplicated content from this site.
@@ -126,6 +126,7 @@ developer/dashboard-local.md
 developer/dashboard-site.md
 developer/dashboard-predevals.md
 developer/dashboard-workflows.md
+developer/dashboard-staging.md
 ```
 
 ```{toctree}


### PR DESCRIPTION
This adds instructions for staging before release of dashboard tools. I will admit that this was a difficult section to write and it is not going to be anywhere near perfect. 

I've done my best to add examples and delve into details where I was able to. 

This will fix #332


Preview: https://hubdocs--336.org.readthedocs.build/en/336/developer/dashboard-staging.html