### PR TITLE
Document scale transformations in the PredEvals user guide

### DIFF
--- a/docs/source/user-guide/dashboards.md
+++ b/docs/source/user-guide/dashboards.md
@@ -385,7 +385,7 @@ In principle, it would be possible to implement `round_filters` by specifying th
 :::
 
 (predevals-scale-transformations)=
-### Scale transformations (optional)
+### Scale transformations for PredEvals (optional)
 
 When a target's values span a wide range of magnitudes, scores computed on the natural scale can be dominated by the largest values. Applying a scale transformation before scoring can give a more balanced evaluation across magnitudes. PredEvals supports configuring scale transformations in `predevals-config.yml` from schema version `v1.1.0` onwards, applied instead of or alongside natural-scale scoring.
 
@@ -400,17 +400,18 @@ Transforms can be configured at two levels:
 - **`transform_defaults`** (top-level, optional): a default transformation applied to every target whose available output types support transformation.
 - A **`transform`** field on an individual target (per-target, optional): a transformation specific to that one target, which *replaces* `transform_defaults` entirely for it.
 
-For example, the abbreviated config below sets a default transform, has the first target inherit it, the second target use its own transform instead, and the third opt out:
+The structure of a `transform` block and the functions available are detailed below, but it may be easier to start with an illustrative case. In the abbreviated config below, a default transform is set, the first target inherits it, the second target uses its own transform instead, and the third opts out:
 
 ```yaml
 transform_defaults:          # applies to all transformable targets by default
   fun: log_shift
   args:
     offset: 1
+  label: log                 # dashboard label for the transformed scale, e.g. "WIS (log)"
 targets:
 - target_id: wk inc flu hosp
   metrics: [wis]
-  # no transform field -> inherits transform_defaults (log_shift)
+  # no transform field -> inherits transform_defaults (log_shift, labelled "log")
 - target_id: wk inc covid hosp
   metrics: [wis]
   transform:                 # replaces transform_defaults for this target
@@ -452,7 +453,7 @@ A target's single resolved transform applies uniformly to **every transformable 
 | `sample` | Not yet — support is under consideration |
 | `pmf` | No (categorical output types are not meaningfully transformed) |
 
-Metrics computed on a non-transformable output type (for example, the pmf metrics `log_score` or `rps`) are always scored on the natural scale and receive no transformed-scale column. See the [hubEvals metric × output-type compatibility reference](https://hubverse-org.github.io/hubEvals/reference/score_model_out.html#details) for which metrics apply to which output types.
+Metrics computed on a non-transformable output type (for example, the pmf metrics `log_score` or `rps`) are always scored on the natural scale and receive no transformed-scale column. See the [hubEvals `score_model_out()` documentation details](https://hubverse-org.github.io/hubEvals/reference/score_model_out.html#details) for the definition of each metric (e.g. what `wis` or `ae_median` mean) and which metrics (e.g. `wis`) can be applied to each output type (e.g. `quantile`).
 
 #### Opting a target out
 
@@ -467,6 +468,7 @@ transform_defaults:
   fun: log_shift
   args:
     offset: 1
+  label: log
 targets:
 - target_id: wk inc flu hosp
   metrics:
@@ -479,12 +481,12 @@ targets:
   transform: false
 ```
 
-In this example, `wk inc flu hosp` inherits `log_shift` (with `offset: 1`) from `transform_defaults`. The categorical target `wk flu hosp rate category` opts out explicitly with `transform: false`.
+In this example, `wk inc flu hosp` inherits `log_shift` (with `offset: 1`, labelled `log`) from `transform_defaults`, so its transformed-scale scores appear in the dashboard as e.g. `WIS (log)`. The categorical target `wk flu hosp rate category` opts out explicitly with `transform: false`.
 
 (predevals-transform-output)=
 #### How transformed scores appear in the dashboard
 
-When a transform applies to a target, the dashboard presents the transformed-scale metrics labelled with the transform's `label` in parentheses — for example, `WIS (log)` alongside `WIS`, or `Rel. WIS (log)` alongside `Rel. WIS`.
+When a transform applies to a target, the dashboard presents the transformed-scale metrics labelled with the transform's `label` in parentheses. In the example above, `label: log` means the transformed `WIS` appears as `WIS (log)` alongside the natural-scale `WIS` (and `Rel. WIS (log)` alongside `Rel. WIS`).
 
 <!-- TODO: add a screenshot of the evaluations table showing transformed-scale metric columns (e.g. `Rel. WIS (log)`) once the predevals dashboard UI for transforms is finalised, matching the screenshots earlier on this page. See review on hubverse-org/hubDocs#477. -->
 

--- a/docs/source/user-guide/dashboards.md
+++ b/docs/source/user-guide/dashboards.md
@@ -384,6 +384,84 @@ In principle, it would be possible to implement `round_filters` by specifying th
 
 :::
 
+(predevals-scale-transformations)=
+### Scale transformations (optional)
+
+For targets whose values span orders of magnitude (for example, count-based forecasts), it can be useful to evaluate predictions on a transformed scale rather than (or in addition to) the natural scale. PredEvals supports configuring scale transformations as part of `predevals-config.yml` from schema version `v1.1.0` onwards.
+
+To opt in, update your config's `schema_version` to the v1.1.0 URL:
+
+```yaml
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
+```
+
+Transforms can be configured at two levels:
+
+- **`transform_defaults`** (top-level, optional): a default transformation applied to every target whose available output types support transformation.
+- **`targets[*].transform`** (per-target, optional): a transformation specific to one target. A per-target `transform` *replaces* `transform_defaults` entirely for that target. There is no merge between the two blocks.
+
+Each `transform` block, whether at the top level or per-target, has the following structure:
+
+| Property | Required | Description |
+| -------- | -------- | ----------- |
+| `fun`    | yes      | Name of the transform function. Must be one of the supported values listed below. |
+| `args`   | no       | Optional named arguments passed to `fun` (for example, `offset` for `log_shift`). Argument names must match the chosen function's formals. |
+| `append` | no       | If `true` (default), transformed-scale scores are produced in addition to natural-scale scores. If `false`, only transformed-scale scores are produced. |
+| `label`  | no       | Optional human-readable label associated with this transformation (for example, `log`). |
+
+#### Supported transform functions
+
+The schema restricts `fun` to the following functions, supported by the hubverse dashboards:
+
+| `fun`        | Source         | Description                                                              |
+| ------------ | -------------- | ------------------------------------------------------------------------ |
+| `log_shift`  | `scoringutils` | Natural log after adding a positive offset (set via `args.offset`). Useful when forecasts may be zero. |
+| `log1p`      | base R         | Natural log of `(1 + x)`. |
+| `log`        | base R         | Natural log (base e). |
+| `log10`      | base R         | Log base 10. |
+| `log2`       | base R         | Log base 2. |
+| `sqrt`       | base R         | Square root. |
+
+#### Opting a target out
+
+To exclude a single target from an inherited `transform_defaults` (without removing the default for other targets), set `transform: false` on that target.
+
+#### Example
+
+```yaml
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
+rounds_idx: 0
+transform_defaults:
+  fun: log_shift
+  args:
+    offset: 1
+targets:
+- target_id: wk inc flu hosp
+  metrics:
+  - wis
+  - ae_median
+- target_id: wk flu hosp rate category
+  metrics:
+  - log_score
+  - rps
+  transform: false
+```
+
+In this example, `wk inc flu hosp` inherits `log_shift` (with `offset: 1`) from `transform_defaults`. The categorical target `wk flu hosp rate category` opts out explicitly with `transform: false`.
+
+#### Validation
+
+The configuration validator surfaces clear errors and warnings for transform-related misconfigurations:
+
+- **Unknown `fun` value.** A `fun` value outside the allowlist is rejected at schema validation time.
+- **Invalid `args`.** If `args` includes a name the chosen `fun` does not accept, validation fails with the list of allowed argument names.
+- **Explicit transform on a target with no transformable output types** (for example, a `pmf`-only target with an explicit `transform` block): validation fails. Targets that cannot be meaningfully transformed should use `transform: false` or be omitted from a configuration that sets `transform_defaults`.
+- **Inherited transform on a target with no transformable output types.** If `transform_defaults` is configured but the target's available output types do not support transformation, validation emits a warning. Setting `transform: false` on the target silences the warning.
+
+#### Backwards compatibility
+
+Existing v1.0.1 configurations continue to validate against schema v1.1.0 without any changes. Migrating the `schema_version` URL is only required if you want to opt into transform configuration.
+
 (predevals-limitations)=
 ### PredEvals limitations and requirements
 

--- a/docs/source/user-guide/dashboards.md
+++ b/docs/source/user-guide/dashboards.md
@@ -387,9 +387,9 @@ In principle, it would be possible to implement `round_filters` by specifying th
 (predevals-scale-transformations)=
 ### Scale transformations (optional)
 
-For targets whose values span orders of magnitude (for example, count-based forecasts), it can be useful to evaluate predictions on a transformed scale rather than (or in addition to) the natural scale. PredEvals supports configuring scale transformations as part of `predevals-config.yml` from schema version `v1.1.0` onwards.
+When a target's values span a wide range of magnitudes, scores computed on the natural scale can be dominated by the largest values. Applying a scale transformation before scoring can give a more balanced evaluation across magnitudes. PredEvals supports configuring scale transformations in `predevals-config.yml` from schema version `v1.1.0` onwards, applied instead of or alongside natural-scale scoring.
 
-To opt in, update your config's `schema_version` to the v1.1.0 URL:
+Scale transformations require schema version `v1.1.0` or later. If your config's `schema_version` points to an earlier version, update it to a version that supports transforms — for example, the one that introduced them:
 
 ```yaml
 schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
@@ -398,29 +398,41 @@ schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/
 Transforms can be configured at two levels:
 
 - **`transform_defaults`** (top-level, optional): a default transformation applied to every target whose available output types support transformation.
-- **`targets[*].transform`** (per-target, optional): a transformation specific to one target. A per-target `transform` *replaces* `transform_defaults` entirely for that target. There is no merge between the two blocks.
+- **`targets[*].transform`** (per-target, optional): a transformation specific to one target. A per-target `transform` *replaces* `transform_defaults` entirely for that target.
 
 Each `transform` block, whether at the top level or per-target, has the following structure:
 
 | Property | Required | Description |
 | -------- | -------- | ----------- |
 | `fun`    | yes      | Name of the transform function. Must be one of the supported values listed below. |
-| `args`   | no       | Optional named arguments passed to `fun` (for example, `offset` for `log_shift`). Argument names must match the chosen function's formals. |
-| `append` | no       | If `true` (default), transformed-scale scores are produced in addition to natural-scale scores. If `false`, only transformed-scale scores are produced. |
-| `label`  | no       | Optional human-readable label associated with this transformation (for example, `log`). |
+| `args`   | no       | Optional named arguments passed to `fun` (for example, `offset` for `log_shift`). Argument names must match the chosen function's formals (excluding the data argument itself). |
+| `append` | no       | If `true` (default), transformed-scale scores are produced *in addition to* natural-scale scores. If `false`, *only* transformed-scale scores are produced. |
+| `label`  | no       | Optional short human-readable label for the transformed scale (for example, `log`). This label identifies the transformed scale in the dashboard, shown in parentheses next to the metric name, e.g. `WIS (log)` (see [How transformed scores appear](#predevals-transform-output) below). If omitted, the `fun` name is used as the label. |
 
 #### Supported transform functions
 
-The schema restricts `fun` to the following functions, supported by the hubverse dashboards:
+The schema restricts `fun` to the following allowlist of functions, all of which are strictly monotonic and supported by the hubverse dashboards:
 
-| `fun`        | Source         | Description                                                              |
-| ------------ | -------------- | ------------------------------------------------------------------------ |
-| `log_shift`  | `scoringutils` | Natural log after adding a positive offset (set via `args.offset`). Useful when forecasts may be zero. |
-| `log1p`      | base R         | Natural log of `(1 + x)`. |
-| `log`        | base R         | Natural log (base e). |
-| `log10`      | base R         | Log base 10. |
-| `log2`       | base R         | Log base 2. |
-| `sqrt`       | base R         | Square root. |
+| `fun`        | Source         | Computes                                                                 | Notable arguments |
+| ------------ | -------------- | ------------------------------------------------------------------------ | ----------------- |
+| `log_shift`  | [`scoringutils::log_shift()`](https://epiforecasts.io/scoringutils/reference/log_shift.html) | Natural logarithm after adding an `offset` to the values: `log(x + offset)`. | `offset` (default `0`), `base` (default `e`). With the default `offset = 0` this is a plain natural log; set `offset: 1` (or another positive value) when forecasts can be zero, since `log(0)` is undefined. |
+| `log1p`      | [base R](https://rdrr.io/r/base/Log.html) | Natural logarithm of `(1 + x)`, i.e. `log(1 + x)`. | — |
+| `log`        | [base R](https://rdrr.io/r/base/Log.html) | Natural logarithm (base *e*). Undefined at `0`. | `base` (default *e*). |
+| `log10`      | [base R](https://rdrr.io/r/base/Log.html) | Base-10 logarithm. | — |
+| `log2`       | [base R](https://rdrr.io/r/base/Log.html) | Base-2 logarithm. | — |
+| `sqrt`       | [base R](https://rdrr.io/r/base/MathFun.html) | Square root. | — |
+
+#### Which output types are transformed
+
+A target's single resolved transform applies uniformly to **every transformable output type** the target declares. The transformable output types are:
+
+| Output type | Transformable? |
+| ----------- | -------------- |
+| `mean`, `median`, `quantile` | Yes |
+| `sample` | Not yet — support is under consideration |
+| `pmf` | No (categorical output types are not meaningfully transformed) |
+
+Metrics computed on a non-transformable output type (for example, the pmf metrics `log_score` or `rps`) are always scored on the natural scale and receive no transformed-scale column. See the [hubEvals metric × output-type compatibility reference](https://hubverse-org.github.io/hubEvals/reference/score_model_out.html#details) for which metrics apply to which output types.
 
 #### Opting a target out
 
@@ -449,6 +461,16 @@ targets:
 
 In this example, `wk inc flu hosp` inherits `log_shift` (with `offset: 1`) from `transform_defaults`. The categorical target `wk flu hosp rate category` opts out explicitly with `transform: false`.
 
+(predevals-transform-output)=
+#### How transformed scores appear in the dashboard
+
+When a transform applies to a target, the dashboard presents the transformed-scale metrics labelled with the transform's `label` in parentheses — for example, `WIS (log)` alongside `WIS`, or `Rel. WIS (log)` alongside `Rel. WIS`.
+
+- With **`append: true`** (the default), both the natural-scale and transformed-scale version of each affected metric are available.
+- With **`append: false`**, only the transformed-scale version is shown.
+
+Two metric families — interval coverage (for example `50% Cov.`, `95% Cov.`) and bias — are mathematically unchanged by any monotonic transform, so they are shown only once, with no separate transformed-scale variant.
+
 #### Validation
 
 The configuration validator surfaces clear errors and warnings for transform-related misconfigurations:
@@ -456,7 +478,7 @@ The configuration validator surfaces clear errors and warnings for transform-rel
 - **Unknown `fun` value.** A `fun` value outside the allowlist is rejected at schema validation time.
 - **Invalid `args`.** If `args` includes a name the chosen `fun` does not accept, validation fails with the list of allowed argument names.
 - **Explicit transform on a target with no transformable output types** (for example, a `pmf`-only target with an explicit `transform` block): validation fails. Targets that cannot be meaningfully transformed should use `transform: false` or be omitted from a configuration that sets `transform_defaults`.
-- **Inherited transform on a target with no transformable output types.** If `transform_defaults` is configured but the target's available output types do not support transformation, validation emits a warning. Setting `transform: false` on the target silences the warning.
+- **Inherited transform on a target with no transformable output types.** If `transform_defaults` is configured but the target's available output types do not support transformation, validation emits a warning and the transform is silently skipped for that target at scoring time. Setting `transform: false` on the target silences the warning.
 
 #### Backwards compatibility
 

--- a/docs/source/user-guide/dashboards.md
+++ b/docs/source/user-guide/dashboards.md
@@ -292,7 +292,7 @@ It is generally recommended that the baseline model used for relative skill scor
 
 
 ```yaml
-schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.0.1/config_schema.json
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
 rounds_idx: 0
 targets:
 - target_id: wk inc flu hosp
@@ -354,10 +354,10 @@ task_id_text:
     ...
 ```
 
-This file is written in the [YAML format](https://en.wikipedia.org/wiki/YAML). You can view the [raw schema](https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.0.1/config_schema.json) for this file to see the detailed specification of its contents, or use the widget below to explore the schema interactively:
+This file is written in the [YAML format](https://en.wikipedia.org/wiki/YAML). You can view the [raw schema](https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json) for this file to see the detailed specification of its contents, or use the widget below to explore the schema interactively:
 
 
-<script src="../_static/docson/widget.js" data-schema="https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.0.1/config_schema.json"></script>
+<script src="../_static/docson/widget.js" data-schema="https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json"></script>
 
 
 PredEvals supports scoring for multiple targets. We could specify another target for evaluation by adding an entry for it at the same level as the `"wk inc flu hosp"` target, complete with specifications for the `target_id`, the `metrics` and `relative_metrics` to compute, the `baseline` to use for relative metrics (if applicable), and the task id variables to `disaggregate_by` for that target.
@@ -398,7 +398,27 @@ schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/
 Transforms can be configured at two levels:
 
 - **`transform_defaults`** (top-level, optional): a default transformation applied to every target whose available output types support transformation.
-- **`targets[*].transform`** (per-target, optional): a transformation specific to one target. A per-target `transform` *replaces* `transform_defaults` entirely for that target.
+- A **`transform`** field on an individual target (per-target, optional): a transformation specific to that one target, which *replaces* `transform_defaults` entirely for it.
+
+For example, the abbreviated config below sets a default transform, has the first target inherit it, the second target use its own transform instead, and the third opt out:
+
+```yaml
+transform_defaults:          # applies to all transformable targets by default
+  fun: log_shift
+  args:
+    offset: 1
+targets:
+- target_id: wk inc flu hosp
+  metrics: [wis]
+  # no transform field -> inherits transform_defaults (log_shift)
+- target_id: wk inc covid hosp
+  metrics: [wis]
+  transform:                 # replaces transform_defaults for this target
+    fun: sqrt
+- target_id: wk flu hosp rate category
+  metrics: [log_score]
+  transform: false           # opts this target out of transform_defaults
+```
 
 Each `transform` block, whether at the top level or per-target, has the following structure:
 
@@ -466,6 +486,9 @@ In this example, `wk inc flu hosp` inherits `log_shift` (with `offset: 1`) from 
 
 When a transform applies to a target, the dashboard presents the transformed-scale metrics labelled with the transform's `label` in parentheses — for example, `WIS (log)` alongside `WIS`, or `Rel. WIS (log)` alongside `Rel. WIS`.
 
+<!-- TODO: add a screenshot of the evaluations table showing transformed-scale metric columns (e.g. `Rel. WIS (log)`) once the predevals dashboard UI for transforms is finalised, matching the screenshots earlier on this page. See review on hubverse-org/hubDocs#477. -->
+
+
 - With **`append: true`** (the default), both the natural-scale and transformed-scale version of each affected metric are available.
 - With **`append: false`**, only the transformed-scale version is shown.
 
@@ -521,7 +544,7 @@ If your hub is using a non-standard scoring metric, i.e not one on the [Score mo
 For a more concrete example, let us say our `predevals-config.yml` looks like this:
 
 ```yaml
-schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.0.1/config_schema.json
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.1.0/config_schema.json
 rounds_idx: 0
 targets:
 - target_id: resources_used


### PR DESCRIPTION
## Summary

Documents the **scale transformations** feature for the PredEvals evaluation module, extending the "Scale transformations" section in `docs/source/user-guide/dashboards.md`.

Closes #464.

> [!IMPORTANT]
> **The feature is not fully available yet.** `hubPredEvalsData` v1.1.0 (the release that introduces transform support) is still being finalised, and the dashboard-side presentation is in progress. This PR **queues the docs up in preparation** for the release and to **elicit early review**. It should land alongside (or just after) the v1.1.0 release rather than ahead of it.

## What's in here

The section was reconciled against `hubPredEvalsData` v1.1.0 as actually implemented (schema, scoring, options generation, and the still-open invariant-metric gating PR), and reframed around what hub admins see in the dashboard rather than backend file formats:

- **Supported transform functions** — full allowlist (`log_shift`, `sqrt`, `log1p`, `log`, `log10`, `log2`) with sources, R-doc links, and the `log_shift` offset note.
- **Which output types are transformed** — `mean`/`median`/`quantile` yes; `sample` under consideration; `pmf` not transformable.
- **How transformed scores appear in the dashboard** — the parenthetical label presentation (e.g. `WIS (log)` alongside `WIS`) and `append` behaviour, with the invariant metrics (interval coverage, bias) shown once.
- **Validation behaviour** — explicit transform on a non-transformable target errors; inherited `transform_defaults` warns and is skipped.

## Review asks

- Is the level of detail right for the user guide, or too much?
- Wording/framing on the dashboard presentation, especially before the predevals UI is finalised.

## Verification

- Docs build locally (`sphinx-build`) with no new warnings.
- `codespell` and `trailing-whitespace` pre-commit hooks pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
