### PR TITLE
Improve cite.md page and fix broken anchor links

### DIFF
--- a/docs/source/overview/cite.md
+++ b/docs/source/overview/cite.md
@@ -1,49 +1,81 @@
 # How to cite
 
 ## Hubverse project
-To cite the **hubverse project** as a whole, please cite the project descriptor preprint:
-```{admonition} hubverse project citation
-Consortium of Infectious Disease Modeling Hubs; Kerr M, Borchering R, Castro Rivadeneira AJ, Contamin L, Funk S, Hochheiser H, et al. [A software platform for collaborative infectious disease modelling](https://www.nature.com/articles/s44360-026-00145-7) [Internet]. Nature Health. 2026;s44360-026-00145-7. Available from: https://www.nature.com/articles/s44360-026-00145-7
-```
+To cite the **hubverse project** as a whole, please cite the project descriptor paper:
 
-BibTeX:
+::::{tab-set}
+:::{tab-item} APA
+Consortium of Infectious Disease Modeling Hubs, Kerr, M., Borchering, R., Castro Rivadeneira, A. J., Contamin, L., Funk, S., Hochheiser, H., Howerton, E., Krystalli, A., Shandross, L., & Reich, N. G. (2026). [A software platform for collaborative infectious disease modelling](https://www.nature.com/articles/s44360-026-00145-7). *Nature Health*, Article s44360-026-00145-7. [https://doi.org/10.1038/s44360-026-00145-7](https://doi.org/10.1038/s44360-026-00145-7)
+:::
+:::{tab-item} Vancouver
+Consortium of Infectious Disease Modeling Hubs, Kerr M, Borchering R, Castro Rivadeneira AJ, Contamin L, Funk S, Hochheiser H, Howerton E, Krystalli A, Shandross L, Reich NG. [A software platform for collaborative infectious disease modelling](https://www.nature.com/articles/s44360-026-00145-7). Nat Health. 2026; Article s44360-026-00145-7. doi: [10.1038/s44360-026-00145-7](https://doi.org/10.1038/s44360-026-00145-7).
+:::
+:::{tab-item} BibTeX
 ```
 @article{cidmh2026-hubverse,
-	title = {A software platform for collaborative infectious disease modelling},
-	author = {{Consortium of Infectious Disease Modeling Hubs} and Kerr, Melissa and Borchering, Rebecca and Castro Rivadeneira, Alvaro J. and Contamin, Lucie and Funk, Sebastian and Hochheiser, Harry and Howerton, Emily and Krystalli, Anna and Shandross, Li and Reich, Nicholas G.},
-	journal = {Nature Health},
-	year = {2026},
-	url = {https://www.nature.com/articles/s44360-026-00145-7},
-	doi = {10.1038/s44360-026-00145-7},
+	title     = {A software platform for collaborative infectious disease modelling},
+	author    = {{Consortium of Infectious Disease Modeling Hubs} and Kerr, Melissa and Borchering, Rebecca and Castro Rivadeneira, Alvaro J. and Contamin, Lucie and Funk, Sebastian and Hochheiser, Harry and Howerton, Emily and Krystalli, Anna and Shandross, Li and Reich, Nicholas G.},
+	journal   = {Nature Health},
+	year      = {2026},
+	doi       = {10.1038/s44360-026-00145-7},
+	url       = {https://www.nature.com/articles/s44360-026-00145-7},
 }
 ```
+:::
+::::
 
 ## HubEnsembles package
-If you used the **hubEnsembles** package in your work, please cite the following preprint:
-```{admonition} hubEnsembles citation
-Shandross L, Howerton E, Contamin L, Hochheiser H, Krystalli A, Consortium of Infectious Disease Modeling Hubs, et al. [Multi-Model Ensembles in Infectious Disease and Public Health: Methods, Interpretation, and Implementation in R](https://onlinelibrary.wiley.com/doi/10.1002/sim.70333) [Internet]. Statistics in Medicine. 2026;45(1–2):e70333. Available from: https://onlinelibrary.wiley.com/doi/10.1002/sim.70333
+If you used the **hubEnsembles** package in your work, please cite the following paper:
+
+::::{tab-set}
+:::{tab-item} APA
+Shandross, L., Howerton, E., Contamin, L., Hochheiser, H., Krystalli, A., Consortium of Infectious Disease Modeling Hubs, et al. (2026). [Multi-model ensembles in infectious disease and public health: Methods, interpretation, and implementation in R](https://onlinelibrary.wiley.com/doi/10.1002/sim.70333). *Statistics in Medicine*, *45*(1–2), e70333. [https://doi.org/10.1002/sim.70333](https://doi.org/10.1002/sim.70333)
+:::
+:::{tab-item} Vancouver
+Shandross L, Howerton E, Contamin L, Hochheiser H, Krystalli A, Consortium of Infectious Disease Modeling Hubs, et al. [Multi-model ensembles in infectious disease and public health: Methods, interpretation, and implementation in R](https://onlinelibrary.wiley.com/doi/10.1002/sim.70333). Stat Med. 2026;45(1–2):e70333. doi: [10.1002/sim.70333](https://doi.org/10.1002/sim.70333).
+:::
+:::{tab-item} BibTeX
 ```
+@article{shandross2026multi,
+	title     = {Multi-Model Ensembles in Infectious Disease and Public Health: {Methods}, Interpretation, and Implementation in {R}},
+	author    = {Shandross, Li and Howerton, Emily and Contamin, Lucie and Hochheiser, Harry and Krystalli, Anna and {Consortium of Infectious Disease Modeling Hubs} and others},
+	journal   = {Statistics in Medicine},
+	volume    = {45},
+	number    = {1--2},
+	pages     = {e70333},
+	year      = {2026},
+	doi       = {10.1002/sim.70333},
+	url       = {https://onlinelibrary.wiley.com/doi/10.1002/sim.70333},
+}
+```
+:::
+::::
 
 ## HubDocs site
 To cite the [**hubverse documentation site**](https://docs.hubverse.io/en/latest/), please use the format below. Be sure to update the release number and date. To find the most current release number and date, go to the [hubDocs GitHub repository](https://github.com/hubverse-org/hubDocs) and look for the information in the middle of the right-hand column under **Releases**.
-```{admonition} hubDocs citation
-The Consortium of Infectious Disease Modeling Hubs. HubDocs: Documentation for Collaborative Modeling Hubs. GitHub release v5.1.0, 13 Jun 2025. URL: https://github.com/hubverse-org/hubDocs Available from: https://docs.hubverse.io/en/latest/
+
+*Citation follows [APA 7th edition software citation style](https://apastyle.apa.org/style-grammar-guidelines/references/examples).*
+```{admonition} HubDocs citation
+Consortium of Infectious Disease Modeling Hubs. (2025). *[HubDocs: Documentation for collaborative modeling hubs](https://github.com/hubverse-org/hubDocs)* (Version 5.1.0) [Software documentation]. GitHub. https://github.com/hubverse-org/hubDocs Educational site available from: https://docs.hubverse.io/en/latest/
 ```
 
 ## Hubverse landing website
 To cite [**the hubverse landing website**](https://hubverse.io/), please use the format below.
-```{admonition} hubverse website citation
-The Consortium of Infectious Disease Modeling Hubs. Hubverse Website. URL: https://hubverse.io/
+
+*Citation follows [APA 7th edition software citation style](https://apastyle.apa.org/style-grammar-guidelines/references/examples).*
+```{admonition} Hubverse website citation
+Consortium of Infectious Disease Modeling Hubs. (2026). *[Hubverse](https://hubverse.io/)* [Website]. https://hubverse.io/
 ```
 
 ## Specific hubverse packages
 - To cite a specific **hubverse R package**, such as `hubUtils`, run `citation("hubUtils")` in your R console to find the appropriate text.
-- To cite a specific **hubverse Python package**, such as `hub-data`, please use the format below. Be sure to replace the text inside `<angle brackets>`, including the package name, release number, date, repository link, and PyPI page. To find the most current release number, date, search for the specific package in [PyPI](https://pypi.org/) or find the package in the [hubverse Python packages page](https://github.com/orgs/hubverse-org/repositories?q=language%3APython) and look for the information in the middle of the right-hand column under **Releases**.
-```{admonition} hubverse Python package citation
-The Consortium of Infectious Disease Modeling Hubs. &lt;Hubverse Python Package&gt;. GitHub release &lt;version&gt;, &lt;date&gt;. URL: &lt;repository link&gt; Available from: &lt;PyPI link&gt;
+- To cite a specific **hubverse Python package**, such as `hub-data`, please use the format below. Be sure to replace the text inside `<angle brackets>`, including the package name, release number, date, and links. To find the most current release number and date, search for the specific package in [PyPI](https://pypi.org/) or find the package in the [hubverse Python packages page](https://github.com/orgs/hubverse-org/repositories?q=language%3APython) and look for the information in the middle of the right-hand column under **Releases**.
+
+*Citations follow [APA 7th edition software citation style](https://apastyle.apa.org/style-grammar-guidelines/references/examples).*
+```{admonition} Hubverse Python package citation
+Consortium of Infectious Disease Modeling Hubs. (&lt;release year&gt;). *&lt;package name&gt;* (Version &lt;version number&gt;) [Software]. GitHub. &lt;repository URL&gt; Package available from: &lt;PyPI URL&gt;
 ```
 For example, to cite the `hub-data` package, use:
 ```{admonition} hub-data citation
-The Consortium of Infectious Disease Modeling Hubs. hub-data. GitHub release v0.2.0, 10 Nov 2025. URL: https://github.com/hubverse-org/hub-data Available from: https://pypi.org/project/hubdata/0.2.0/
+Consortium of Infectious Disease Modeling Hubs. (2025). *[hub-data](https://github.com/hubverse-org/hub-data)* (Version 0.2.0) [Software]. GitHub. https://github.com/hubverse-org/hub-data Package available from: https://pypi.org/project/hubdata/0.2.0/
 ```
-

--- a/docs/source/overview/cite.md
+++ b/docs/source/overview/cite.md
@@ -5,7 +5,7 @@ To cite the **hubverse project** as a whole, please cite the project descriptor 
 
 ::::{tab-set}
 :::{tab-item} APA
-Consortium of Infectious Disease Modeling Hubs, Kerr, M., Borchering, R., Castro Rivadeneira, A. J., Contamin, L., Funk, S., Hochheiser, H., Howerton, E., Krystalli, A., Shandross, L., & Reich, N. G. (2026). [A software platform for collaborative infectious disease modelling](https://www.nature.com/articles/s44360-026-00145-7). *Nature Health*, Article s44360-026-00145-7. [https://doi.org/10.1038/s44360-026-00145-7](https://doi.org/10.1038/s44360-026-00145-7)
+Consortium of Infectious Disease Modeling Hubs, Kerr, M., Borchering, R., Castro Rivadeneira, A. J., Contamin, L., Funk, S., Hochheiser, H., Howerton, E., Krystalli, A., Shandross, L., & Reich, N. G. (2026). [A software platform for collaborative infectious disease modelling](https://www.nature.com/articles/s44360-026-00145-7). *Nature Health*, Article s44360-026-00145-7. https://doi.org/10.1038/s44360-026-00145-7
 :::
 :::{tab-item} Vancouver
 Consortium of Infectious Disease Modeling Hubs, Kerr M, Borchering R, Castro Rivadeneira AJ, Contamin L, Funk S, Hochheiser H, Howerton E, Krystalli A, Shandross L, Reich NG. [A software platform for collaborative infectious disease modelling](https://www.nature.com/articles/s44360-026-00145-7). Nat Health. 2026; Article s44360-026-00145-7. doi: [10.1038/s44360-026-00145-7](https://doi.org/10.1038/s44360-026-00145-7).
@@ -29,7 +29,7 @@ If you used the **hubEnsembles** package in your work, please cite the following
 
 ::::{tab-set}
 :::{tab-item} APA
-Shandross, L., Howerton, E., Contamin, L., Hochheiser, H., Krystalli, A., Consortium of Infectious Disease Modeling Hubs, et al. (2026). [Multi-model ensembles in infectious disease and public health: Methods, interpretation, and implementation in R](https://onlinelibrary.wiley.com/doi/10.1002/sim.70333). *Statistics in Medicine*, *45*(1–2), e70333. [https://doi.org/10.1002/sim.70333](https://doi.org/10.1002/sim.70333)
+Shandross, L., Howerton, E., Contamin, L., Hochheiser, H., Krystalli, A., Consortium of Infectious Disease Modeling Hubs, et al. (2026). [Multi-model ensembles in infectious disease and public health: Methods, interpretation, and implementation in R](https://onlinelibrary.wiley.com/doi/10.1002/sim.70333). *Statistics in Medicine*, *45*(1–2), e70333. https://doi.org/10.1002/sim.70333
 :::
 :::{tab-item} Vancouver
 Shandross L, Howerton E, Contamin L, Hochheiser H, Krystalli A, Consortium of Infectious Disease Modeling Hubs, et al. [Multi-model ensembles in infectious disease and public health: Methods, interpretation, and implementation in R](https://onlinelibrary.wiley.com/doi/10.1002/sim.70333). Stat Med. 2026;45(1–2):e70333. doi: [10.1002/sim.70333](https://doi.org/10.1002/sim.70333).

--- a/docs/source/user-guide/sample-output-type.md
+++ b/docs/source/user-guide/sample-output-type.md
@@ -4,7 +4,7 @@
 
 The sample `output_type` can represent a probabilistic distribution through a collection of possible future observed values ("samples") that originate from a predictive model. Depending on the model's setup and the hub's configuration settings, different information may be requested or required to identify each sample.
 
-In the hubverse, a "[modeling task](tasks.md)" is defined by a unique combination of task ID column values. You can think of each modeling task as a specific part of the space defined by the [task ID variables](tasks.md#task-id-vars)[^1] that we are interested in predicting. Each modeling task results in a single prediction. (Note that this concept is similar to that of a ["forecast unit" in the scoringutils R package](https://epiforecasts.io/scoringutils/reference/set_forecast_unit.html).)
+In the hubverse, a "[modeling task](tasks.md)" is defined by a unique combination of task ID column values. You can think of each modeling task as a specific part of the space defined by the [task ID variables](#task-id-vars)[^1] that we are interested in predicting. Each modeling task results in a single prediction. (Note that this concept is similar to that of a ["forecast unit" in the scoringutils R package](https://epiforecasts.io/scoringutils/reference/set_forecast_unit.html).)
 
 [^1]: (AKA task IDs, task ID columns) Column(s) in model output that provide details about what is being predicted. Common examples include `target`, `location`, `reference_date`, and `horizon`. These "task ID" columns may also include additional information, such as any conditions or assumptions used to generate the predictions.
 
@@ -28,7 +28,7 @@ How modeling tasks relate to each other determines the structure of this distrib
 
 In many settings, predictions will be made for individual modeling tasks, with no notion of modeling tasks being related to each other or collected into sets (for more on this, see the [compound modeling tasks section](#compound-modeling-tasks)). When predictions are assumed to be made for individual modeling tasks, every modeling task is treated as distinct. In mathematical terms, these samples represent draws from marginal predictive distributions.
 
-Now, suppose we wanted to collect samples for each of the modeling tasks defined in the previous section. The table below shows a dataset with three groups (indicated by `compound_idx`[^2] values 1, 2, and 3) and three samples per group. In this case, the only difference between the modeling tasks here are the horizon. The [`output_type_id` column](model-output.md#column-details)[^3] contains sample indices that are unique across an entire model output file, not just within each group, so each group has distinct indices (1-3, 4-6, and 7-9 respectively). When sampling from marginal distributions, each group corresponds to a single modeling task, so all task ID values are identical within each group. Notice how each group represents samples for a single modeling task.
+Now, suppose we wanted to collect samples for each of the modeling tasks defined in the previous section. The table below shows a dataset with three groups (indicated by `compound_idx`[^2] values 1, 2, and 3) and three samples per group. In this case, the only difference between the modeling tasks here are the horizon. The [`output_type_id` column](#column-details)[^3] contains sample indices that are unique across an entire model output file, not just within each group, so each group has distinct indices (1-3, 4-6, and 7-9 respectively). When sampling from marginal distributions, each group corresponds to a single modeling task, so all task ID values are identical within each group. Notice how each group represents samples for a single modeling task.
 
 [^2]: The `compound_idx` column indicates which rows belong to the same group. In the marginal case shown here, each group contains samples for one modeling task. This column is not a task ID variable and is not typically present in actual model output data.
 
@@ -67,7 +67,7 @@ In this type of setting, a hub will specify a minimum and maximum number of requ
 
 More specifically, the `"output_type_id_params"` property specifies that sample `output_type_id`s must be integers, and there must be exactly (i.e., no more or less than) 3 samples per modeling task (group). The `"value"` specification refers to the predicted values contained in the "value" column (e.g., they must be storable as numeric "double" format and be no less than zero). The `"is_required"` property specifies that samples are a required output type.
 
-Note that samples use an `"output_type_id_params"` block to define allowable values through parameters (like min/max). Other output types use an `"output_type_id"` block that lists required and optional values explicitly. One example for the mean output type is shown below; more information and examples can be found on the [Hub configuration files page](hub-config.md#tasks-metadata) in the `tasks.json` file section.
+Note that samples use an `"output_type_id_params"` block to define allowable values through parameters (like min/max). Other output types use an `"output_type_id"` block that lists required and optional values explicitly. One example for the mean output type is shown below; more information and examples can be found on the [Hub configuration files page](#tasks-metadata) in the `tasks.json` file section.
 
 ```{code-block} json
     "mean": {
@@ -372,7 +372,7 @@ In general, a submission will pass validation if the task ID variables that defi
 To put it another way, samples can only describe "coarser" compound modeling tasks than those defined using the `compound_taskid_set` field. This is why all example submissions in the first row of the table pass validation, yet Example Submission A fails validation when the `compound_taskid_set` does not contain all four task ID variables.
 
 ```{caution}
-[**Derived task IDs**](tasks.md#derived-task-id-variables) are a type of task IDs whose values depend wholly on that of other task ID variables. A common example is the `target_end_date` task ID, which tends to be derived from the combination of the `reference_date` (or `origin_date`) and `horizon` task IDs.
+[**Derived task IDs**](#derived-task-id-variables) are a type of task IDs whose values depend wholly on that of other task ID variables. A common example is the `target_end_date` task ID, which tends to be derived from the combination of the `reference_date` (or `origin_date`) and `horizon` task IDs.
 
 These derived task IDs must be properly configured, or they can cause problems when validating compound modeling tasks by throwing errors when they should not. *If **all** the task ID variables a derived task ID is derived from are part of the `compound_taskid_set`, then that derived task ID must also be a part of the `compound_taskid_set`; otherwise, that derived task ID should be excluded.*
 


### PR DESCRIPTION
This PR improves the `cite.md` page, so that citations are presented in APA, Vancouver and BibTeX formats, as tabs (it looks nice). It also corrects some small mistakes on the formatting. Finally it fixes some broken anchor links from `sample-output-type.md` that I had missed. All these changes have been examined and previewed locally.