### PR TITLE
Complete author list in hubEnsembles BibTeX citation

### DIFF
--- a/docs/source/overview/cite.md
+++ b/docs/source/overview/cite.md
@@ -38,7 +38,7 @@ Shandross L, Howerton E, Contamin L, Hochheiser H, Krystalli A, Consortium of In
 ```
 @article{shandross2026multi,
 	title     = {Multi-Model Ensembles in Infectious Disease and Public Health: {Methods}, Interpretation, and Implementation in {R}},
-	author    = {Shandross, Li and Howerton, Emily and Contamin, Lucie and Hochheiser, Harry and Krystalli, Anna and {Consortium of Infectious Disease Modeling Hubs} and others},
+	author    = {Shandross, Li and Howerton, Emily and Contamin, Lucie and Hochheiser, Harry and Krystalli, Anna and {Consortium of Infectious Disease Modeling Hubs} and Reich, Nicholas G. and Ray, Evan L.},
 	journal   = {Statistics in Medicine},
 	volume    = {45},
 	number    = {1--2},


### PR DESCRIPTION
The BibTeX entry for the hubEnsembles paper in `docs/source/overview/cite.md` previously truncated the author list with `and others` after the sixth author (Consortium of Infectious Disease Modeling Hubs), omitting Nicholas G. Reich and Evan L. Ray.

This replaces `and others` with the two remaining authors so the BibTeX entry lists the complete author list, matching the published paper (doi:10.1002/sim.70333) and the CrossRef record:

Shandross, Howerton, Contamin, Hochheiser, Krystalli, Consortium of Infectious Disease Modeling Hubs, Reich, Ray.

The APA and Vancouver renderings on the same page intentionally keep their `et al.` truncation per their respective style guides; only the BibTeX entry, which should carry the full list for reuse, is updated.