### PR TITLE
Document that the hubverse accepts dates, not datetimes

### DIFF
--- a/docs/source/user-guide/model-output.md
+++ b/docs/source/user-guide/model-output.md
@@ -129,6 +129,9 @@ More detail about each of these column groups is given in the following points:
     2. `output_type_id`{.codeitem} specifies more identifying information specific to the output type, which varies depending on the `output_type`.
 3. `value`{.codeitem} contains the model’s prediction.
 
+:::{note}
+Across all model output columns, the hubverse supports **dates only, not datetimes**. Any date-valued column — whether a task ID such as `reference_date` or `target_date`, or any other column defined with a date data type — must use ISO 8601 date strings in `YYYY-MM-DD` format. See [the note on date values in task ID variables](#task-id-data-types) for details.
+:::
 
 The following table provides more detail on how to configure the three "model output representation" columns based on each model output type.
 

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -182,6 +182,17 @@ We therefore strongly suggest that Hubs adopt the following standard task ID or 
 [^new-vars]: As Hubs define new modeling tasks, they may need to introduce new task ID variables that have not been used before.
 In those cases, the new variables should be added to this list to ensure that the concepts are documented centrally and can be reused in future efforts.
 
+(task-id-data-types)=
+#### Date values in task ID variables
+
+Several standard task ID variables represent dates (for example, `origin_date`{.codeitem}, `forecast_date`{.codeitem}, `reference_date`{.codeitem}, and `target_date`{.codeitem}/`target_end_date`{.codeitem}).
+
+:::{important}
+Date-valued task IDs must be represented as strings in ISO 8601 date format (`YYYY-MM-DD`), for example `"2024-11-07"`.
+
+The hubverse currently supports **dates only, not datetimes**. There is no way to attach a time component (e.g., `2024-11-07T14:30:00`) to a task ID value, and datetimes are not supported anywhere in the hubverse framework. If a modeling task requires finer-than-daily resolution, represent the time component using a separate task ID variable.
+:::
+
 (output-types)=
 ## Output types
 

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -193,17 +193,16 @@ Date-valued task IDs must be represented as strings in ISO 8601 date format (`YY
 The hubverse currently supports **dates only, not datetimes**. There is no datetime type and no time-of-day type anywhere in the hubverse framework, so you cannot attach a time component (e.g., `2024-11-07T14:30:00`) to a task ID value.
 :::
 
-If a modeling task requires finer-than-daily resolution, split the sub-daily component into its own task ID variable. The benefit is *not* that this represents time "properly"; it is that the component can then be encoded as a plain `integer` or `character` value (for example, `hour` as `14`, or `"14:30"`) — data types the hubverse already reads and validates (via its Arrow/R tooling). No time data type is needed, and this works today with no changes to hubData or hubValidations.
+If a modeling task appears to require finer-than-daily resolution, we currently recommend avoiding it where possible. The hubverse has no time or datetime type, so there is no first-class way to represent sub-daily resolution, and the available workaround carries real validation costs (see below). Consider whether a daily-or-coarser formulation can meet your needs first.
+
+If sub-daily resolution is genuinely unavoidable, the only option today is to encode the sub-daily component as a separate task ID variable with a plain `integer` or `character` type (for example, `hour` as `14`, or `"14:30"`). These are types the hubverse already reads and validates via its Arrow/R tooling, with no changes to hubData or hubValidations. Weigh the following before doing so.
 
 :::{warning}
-The hubverse read and validation functions treat such a variable **strictly as an `integer` or `character` column, with no temporal semantics**: no timezone, no time-of-day type, no interpretation of its ordering as time, and no validity checking (for example, `hour` values of `47`, or `"25:99"`, would pass validation unless the hub adds its own custom validation checks). Any temporal meaning lives entirely in the hub's config and the modeler's convention.
+**No temporal semantics.** Such a variable is treated strictly as an `integer` or `character` column: no timezone, no time-of-day type, and no interpretation of its ordering as time. Values are validated like any other task ID, by membership against the accepted values you enumerate in the hub's config, not against any notion of a valid time. An out-of-range value such as `hour = 47` is only rejected if it falls outside the accepted values you have defined.
 
-To keep conventions compatible across hubs and avoid sorting surprises, adopt a canonical encoding — either:
+**Validation performance cost.** The hubverse validates value combinations against an expanded grid, roughly the cartesian product of every task ID's accepted values within a modeling task. A temporal task ID multiplies the size of that grid by its number of accepted values: an hourly variable (24 values) multiplies it about 24 times, while a minute-level variable (1440 values) multiplies it about 1440 times, which can make validation impractically slow and memory-heavy. Keep the resolution as coarse as possible.
 
-- an **`integer`** in a fixed range (e.g., `hour` from `0` to `23`), or
-- a **zero-padded, fixed-width `character` string** (e.g., `"HH:MM"`, so `"09:30"` rather than `"9:30"`).
-
-Because these columns carry no temporal type, character values are sorted lexically (character by character) rather than numerically — so without zero-padding, `"9"` sorts *after* `"10"`. Prefer zero-padded strings or integers to avoid this.
+**Encoding.** These columns carry no temporal type, so character values sort lexically rather than numerically (without zero-padding, `"9"` sorts after `"10"`). If you do introduce one, use a canonical encoding: an `integer` in a fixed range (for example, `0` to `23`), or a zero-padded, fixed-width `character` string (for example, `"09:30"` rather than `"9:30"`).
 :::
 
 (output-types)=

--- a/docs/source/user-guide/tasks.md
+++ b/docs/source/user-guide/tasks.md
@@ -190,7 +190,20 @@ Several standard task ID variables represent dates (for example, `origin_date`{.
 :::{important}
 Date-valued task IDs must be represented as strings in ISO 8601 date format (`YYYY-MM-DD`), for example `"2024-11-07"`.
 
-The hubverse currently supports **dates only, not datetimes**. There is no way to attach a time component (e.g., `2024-11-07T14:30:00`) to a task ID value, and datetimes are not supported anywhere in the hubverse framework. If a modeling task requires finer-than-daily resolution, represent the time component using a separate task ID variable.
+The hubverse currently supports **dates only, not datetimes**. There is no datetime type and no time-of-day type anywhere in the hubverse framework, so you cannot attach a time component (e.g., `2024-11-07T14:30:00`) to a task ID value.
+:::
+
+If a modeling task requires finer-than-daily resolution, split the sub-daily component into its own task ID variable. The benefit is *not* that this represents time "properly"; it is that the component can then be encoded as a plain `integer` or `character` value (for example, `hour` as `14`, or `"14:30"`) — data types the hubverse already reads and validates (via its Arrow/R tooling). No time data type is needed, and this works today with no changes to hubData or hubValidations.
+
+:::{warning}
+The hubverse read and validation functions treat such a variable **strictly as an `integer` or `character` column, with no temporal semantics**: no timezone, no time-of-day type, no interpretation of its ordering as time, and no validity checking (for example, `hour` values of `47`, or `"25:99"`, would pass validation unless the hub adds its own custom validation checks). Any temporal meaning lives entirely in the hub's config and the modeler's convention.
+
+To keep conventions compatible across hubs and avoid sorting surprises, adopt a canonical encoding — either:
+
+- an **`integer`** in a fixed range (e.g., `hour` from `0` to `23`), or
+- a **zero-padded, fixed-width `character` string** (e.g., `"HH:MM"`, so `"09:30"` rather than `"9:30"`).
+
+Because these columns carry no temporal type, character values are sorted lexically (character by character) rather than numerically — so without zero-padding, `"9"` sorts *after* `"10"`. Prefer zero-padded strings or integers to avoid this.
 :::
 
 (output-types)=


### PR DESCRIPTION
## Document that the hubverse accepts dates, not datetimes

Closes #177

### Background

A bug report ([hubValidations#118](https://github.com/hubverse-org/hubValidations/issues/118)) where modelers submitted datetime columns in place of dates surfaced that our docs don't clearly state that the hubverse currently supports **dates only** (ISO 8601, `YYYY-MM-DD`), not datetimes. Our framework cannot currently handle datetimes, so this PR documents the limitation rather than adding support for it.

Placement follows the discussion in #177 (and the linked [team discussion](https://github.com/hubverse-org/.github/discussions/31)): keep the primary note focused on task ID data types, and reiterate the limitation for model output files as a whole. No changes were made to hubValidations or hubData, per that discussion.

### Changes

- **`docs/source/user-guide/tasks.md`** — new `#### Date values in task ID variables` subsection (anchor `task-id-data-types`) at the end of the Task ID variables section. States that date-valued task IDs must be ISO 8601 (`YYYY-MM-DD`) strings, that datetimes are not supported anywhere in the framework, and that sub-daily resolution should be represented with a separate task ID variable.
- **`docs/source/user-guide/model-output.md`** — note in "Details about model output column specifications" reiterating the dates-only limitation across all model output columns, cross-linked to the tasks.md note.

### Notes for reviewers

- Used in-section `important`/`note` admonitions (consistent with these pages) rather than the footnote style originally floated in the issue.
- `sphinx build` succeeds locally with no new warnings; the new anchor and cross-reference resolve.