### PR TITLE
Group weekly pre-commit updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,17 +8,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # group all run-of-the mill updates into a single pull request
+    # SemVer update-type filtering (patch/minor) is not supported for the
+    # pre-commit ecosystem, so group ALL pre-commit updates into a single PR
     groups:
       pre-commit-updates:
         applies-to: version-updates
-        update-types:
-          - patch
-          - minor
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
I am getting separate PRs for patch updates to pre-commits. This was Claude's solution to grouping them as a single PR, since I can't ignore patch updates for pre-commits.