### PR TITLE
Add data-revision warning for retrospective forecasting and evaluation

### DIFF
--- a/docs/source/developer/dashboard-predevals.md
+++ b/docs/source/developer/dashboard-predevals.md
@@ -4,6 +4,10 @@ The evaluations dashboard provides model evaluation scores
 for predictions. The interactivity in the dashboard is provided by the [predevals](https://github.com/hubverse-org/predevals) JavaScript module, which reads in CSV files and produces a
 dashboard interface to view charts and tables summarizing these files.
 
+:::{warning}
+**Forecasting or evaluating retrospectively?** Surveillance data gets revised after it's first reported, so the data version you use matters — evaluating on finalized data can make performance look substantially better than it really was. To *re-generate* forecasts, restrict each forecast's inputs to the data available **as of** its reference date. To *score* forecasts, use the finalized target defined by the hub (which may differ from both the as-of-forecast-time data and the current snapshot). See [data revisions and retrospective evaluation](#data-revisions-warning) for details and links to versioned-data archives.
+:::
+
 The docker image
 [hubPredEvalsData-docker](https://github.com/hubverse-org/hubPredEvalsData-docker)
 provides a thin wrapper around the R Package

--- a/docs/source/developer/dashboard-predevals.md
+++ b/docs/source/developer/dashboard-predevals.md
@@ -5,7 +5,7 @@ for predictions. The interactivity in the dashboard is provided by the [predeval
 dashboard interface to view charts and tables summarizing these files.
 
 :::{warning}
-**Forecasting or evaluating retrospectively?** Surveillance data gets revised after it's first reported, so the data version you use matters — evaluating on finalized data can make performance look substantially better than it really was. To *re-generate* forecasts, restrict each forecast's inputs to the data available **as of** its reference date. To *score* forecasts, use the finalized target defined by the hub (which may differ from both the as-of-forecast-time data and the current snapshot). See [data revisions and retrospective evaluation](#data-revisions-warning) for details and links to versioned-data archives.
+**Forecasting or evaluating retrospectively?** Surveillance data gets revised after it's first reported, so the data version you use matters — generating forecasts from finalized data and then evaluating against it can make performance look substantially better than it really was. To *re-generate* forecasts, restrict each forecast's inputs to the data available **as of** its reference date. To *score* forecasts, use the finalized target defined by the hub (which may differ from both the as-of-forecast-time data and the current snapshot). See [data revisions and retrospective evaluation](#data-revisions-warning) for details and links to versioned-data archives.
 :::
 
 The docker image

--- a/docs/source/user-guide/dashboards.md
+++ b/docs/source/user-guide/dashboards.md
@@ -150,7 +150,7 @@ to include an HTML snippet at the end of every page you would:
 (dashboard-ptc)=
 ## PredTimeChart visualization (optional)
 
-The PredTimeChart visualization module creates an interactive display of step-ahead predictions, including scenario projections, hindcasts, nowcasts, and forecasts. Dashboard users can select different models to include, the reference date (also referred to as the origin date) when predictions were created, and the values of task id variables to show (such as location). The visualization shows predictions alongside the latest available target data and the version of the target that was available at the time the predictions were created.
+The PredTimeChart visualization module creates an interactive display of step-ahead predictions, including scenario projections, hindcasts, nowcasts, and forecasts. Dashboard users can select different models to include, the reference date (also referred to as the origin date) when predictions were created, and the values of task id variables to show (such as location). The visualization shows predictions alongside the latest available target data and the version of the target that was available at the time the predictions were created (see [data revisions and retrospective evaluation](#data-revisions-warning)).
 
 ```{figure} ../images/dashboard-viz-screenshot.png
 ---

--- a/docs/source/user-guide/target-data.md
+++ b/docs/source/user-guide/target-data.md
@@ -28,7 +28,7 @@ document.
 :class: warning
 :name: data-revisions-warning
 
-Forecasts in a real-time hub were made using the data **available at the time**. Surveillance data is often revised after its initial release (reporting delays, backfill, and corrections), so the observed value for a given target date can change in later data versions. In practice, making predictions using finalized data and then evaluated with that same data can make retrospective performance look substantially better than it really was in real time.
+Forecasts in a real-time hub were made using the data **available at the time**. Surveillance data is often revised after its initial release (reporting delays, backfill, and corrections), so the observed value for a given target date can change in later data versions. In practice, generating forecasts from finalized data and then evaluating them against that same data can make retrospective performance look substantially better than it really was in real time.
 
 Because of this, the data version used to **generate** forecasts and the data version used to **score** them are two different things:
 

--- a/docs/source/user-guide/target-data.md
+++ b/docs/source/user-guide/target-data.md
@@ -28,7 +28,7 @@ document.
 :class: warning
 :name: data-revisions-warning
 
-Forecasts in a real-time hub were made using the data **available at the time**. Surveillance data is often revised after its initial release (reporting delays, backfill, and corrections), so the observed value for a given target date can change in later data versions. In practice, evaluating on finalized data can make retrospective performance look substantially better than it really was in real time.
+Forecasts in a real-time hub were made using the data **available at the time**. Surveillance data is often revised after its initial release (reporting delays, backfill, and corrections), so the observed value for a given target date can change in later data versions. In practice, making predictions using finalized data and then evaluated with that same data can make retrospective performance look substantially better than it really was in real time.
 
 Because of this, the data version used to **generate** forecasts and the data version used to **score** them are two different things:
 

--- a/docs/source/user-guide/target-data.md
+++ b/docs/source/user-guide/target-data.md
@@ -24,6 +24,23 @@ document.
 [^truth]: Time series data is sometimes referred to as "ground truth" data, but
     we no longer use this term in the hubverse.
 
+:::{admonition} Data revisions, retrospective forecasting, and evaluation
+:class: warning
+:name: data-revisions-warning
+
+Forecasts in a real-time hub were made using the data **available at the time**. Surveillance data is often revised after its initial release (reporting delays, backfill, and corrections), so the observed value for a given target date can change in later data versions. In practice, evaluating on finalized data can make retrospective performance look substantially better than it really was in real time.
+
+Because of this, the data version used to **generate** forecasts and the data version used to **score** them are two different things:
+
+- **Generating forecasts retrospectively.** If you attempt to generate new forecasts retrospectively using the latest version of the target data, you are not reproducing the information forecasters actually had, and your results may be misleading. For a faithful replication, restrict each forecast's inputs to the data as it was available **as of** that forecast's reference date.
+- **Scoring.** Score forecasts against an appropriate **"finalized"** version of the data — the version that was defined *in advance* as the prediction target. This "final" version may vary depending on the hub setup: for example, the data as of the end of the season, or each data point given a fixed amount of time to stabilize (e.g. the value after a set number of weeks of revisions). Check the hub's documentation for how its target is defined.
+
+To obtain the data as it was reported on a past date:
+
+- If this hub publishes versioned target data (an `as_of` column / `versioned: true` in `target-data.json`) or versions its target data in the repository's git history, reconstruct the version available at the relevant date from the hub itself.
+- Otherwise, use an external archive that preserves data revisions — for example, [Delphi's Epidata API](https://delphi.cmu.edu/epidata/v5/docs), accessible via the [epidatr](https://cmu-delphi.github.io/epidatr/) (R) and [epidatpy](https://cmu-delphi.github.io/epidatpy/) (Python) clients.
+:::
+
 ## Uses of target time series data and oracle output
 
 Each data format is useful for different purposes (see table below).
@@ -91,6 +108,10 @@ of those targets will be part of the unit of observation, with a column such as
 Time series data are expected to be compiled from an authoritative upstream
 data source after each target date.
 Because of reporting delays, the data may initially be represented by one value that could be updated in one or more subsequent versions of the data.
+
+:::{seealso}
+Recording data versions is what makes a faithful retrospective analysis possible. For why this matters when hub data is reused, see [data revisions and retrospective evaluation](#data-revisions-warning).
+:::
 
 ```{table} Data recorded on December 3 for December 3 shows an observation of 420
 | *as\_of*     | target_end_date       | location | observation |


### PR DESCRIPTION
Adds a prominent warning that hub data must be used carefully for retrospective forecast generation and evaluation, since surveillance data is revised over time. Comes out of a suggestion from the Delphi group; wording was discussed and agreed in this [discussion](https://github.com/orgs/hubverse-org/discussions/45).

Changes:
- `user-guide/target-data.md`: full warning admonition (anchor `data-revisions-warning`), plus a `seealso` back-link from the `as_of` versioning section.
- `developer/dashboard-predevals.md`: short warning on the evaluations dashboard page.
- `user-guide/dashboards.md`: inline cross-reference where the PredTimeChart section discusses showing the as-of data version.

All cross-references point to the single canonical anchor and resolve in a clean `sphinx-build`.